### PR TITLE
Support ROCm

### DIFF
--- a/llamafile/compcap.cu
+++ b/llamafile/compcap.cu
@@ -1,7 +1,20 @@
 // https://stackoverflow.com/a/40695640/1653720
 #include <cstdio>
 #include <cstdlib>
+#if !defined(USE_HIP)
 #include <cuda_runtime_api.h>
+#else
+#include <hip/hip_runtime_api.h>
+#endif
+
+#if defined(USE_HIP)
+#define cudaGetDeviceProperties hipGetDeviceProperties
+#define cudaGetDeviceCount hipGetDeviceCount
+#define cudaError_t hipError_t
+#define cudaDeviceProp hipDeviceProp_t
+#define cudaSuccess hipSuccess
+#define cudaGetErrorString hipGetErrorString
+#endif
 
 int main(int argc, char *argv[]) {
   cudaDeviceProp prop;
@@ -25,6 +38,11 @@ int main(int argc, char *argv[]) {
     fprintf(stderr, "cudaGetDeviceProperties() for device device_index failed: %s\n", cudaGetErrorString(status));
     return -1;
   }
+
+#if !defined(USE_HIP)
   int v = prop.major * 10 + prop.minor;
   printf("%d", v);
+#else
+  printf("%s", prop.gcnArchName);
+#endif
 }

--- a/llamafile/cuda.c
+++ b/llamafile/cuda.c
@@ -45,13 +45,13 @@ __static_yoink("llama.cpp/ggml-backend-impl.h");
 
 #define USE_HIP 1
 
-#if !defined(USE_HIP)
+#if !USE_HIP
 #define NVCC_LIBS "-lcublas"
 #else
 #define NVCC_LIBS "-lhipblas", "-lrocblas"
 #endif
 
-#if !defined(USE_HIP)
+#if !USE_HIP
 #define NVCC_FLAGS "--shared",                                          \
         "--forward-unknown-to-host-compiler",                           \
         "-use_fast_math",                                               \
@@ -228,7 +228,7 @@ static bool Compile(const char *src,
 // set $CUDA_PATH to empty string to disable cuda
 static bool GetNvccPath(char path[static PATH_MAX]) {
     const char *cuda_path;
-#if !defined(USE_HIP)
+#if !USE_HIP
     if (commandv(IsWindows() ? "nvcc.exe" : "nvcc", path, PATH_MAX)) {
 #else
     if (commandv(IsWindows() ? "hipcc.bin.exe" : "hipcc", path, PATH_MAX)) {
@@ -244,7 +244,7 @@ static bool GetNvccPath(char path[static PATH_MAX]) {
         strlcpy(path, "/usr/local/cuda/bin/", PATH_MAX);
     }
     strlcat(path, USE_HIP ? "nvcc" : "hipcc", PATH_MAX);
-#if !defined(USE_HIP)
+#if !USE_HIP
     if (IsWindows()) {
         strlcat(path, ".exe", PATH_MAX);
     }
@@ -323,7 +323,7 @@ static dontinline bool GetNvccArchFlag(char *nvcc, char flag[static 32]) {
         return false;
     }
 
-#if !defined(USE_HIP)
+#if !USE_HIP
     // parse output of detector
     char *endptr;
     if (!*ibuf || !strtol(ibuf, &endptr, 10) || *endptr) {

--- a/llamafile/cuda.c
+++ b/llamafile/cuda.c
@@ -69,7 +69,7 @@ __static_yoink("llama.cpp/ggml-backend-impl.h");
 #else
 #define NVCC_FLAGS "-shared",                                          \
         "-use_fast_math",                                               \
-        "-fPIC", "-O3", "-march=native", "-mtune=native",               \
+        IsWindows() ? "" : "-fPIC", "-O3", "-march=native", "-mtune=native",               \
         "-DNDEBUG",                                                     \
         "-DGGML_BUILD=1",                                               \
         "-DGGML_SHARED=1",                                              \
@@ -231,7 +231,7 @@ static bool GetNvccPath(char path[static PATH_MAX]) {
 #if !defined(USE_HIP)
     if (commandv(IsWindows() ? "nvcc.exe" : "nvcc", path, PATH_MAX)) {
 #else
-    if (commandv("hipcc", path, PATH_MAX)) {
+    if (commandv(IsWindows() ? "hipcc.bin.exe" : "hipcc", path, PATH_MAX)) {
 #endif
         return true;
     } else if ((cuda_path = getenv("CUDA_PATH"))) {


### PR DESCRIPTION
Just a quick ROCm port. Tested on Linux. For #92 

In case you have an issue about loading `libamdhip64.so`, try setting the execstack bit like `sudo execstack -c /opt/rocm/lib/libamdhip64.so.5`

Tested on W7900/7900XTX GPU on Ubuntu 20.04.

Compilation steps should be exactly the same as before. Simply `make -j8` and `make install PREFIX=/usr/local` like the README says.


TODO:
1. Compile on Windows using HIP SDK + cosmos bash?
3. Check if these changes don't break CUDA compilation?
4. Maybe check CUDA vs. HIP availability more dynamically instead of macros via `compcap.cu` program?
5. tinyblas.cu needs to be HIP-ified


For Windows support in (1), HIP SDK include path(s) might also have to be applied for supporting hipBLAS/rocBLAS.