### PR TITLE
ggml-cpu: re-hook llamafile MoE matmul on x86 (partial fix for #973)

### DIFF
--- a/llama.cpp.patches/patches/ggml_src_ggml-cpu_ggml-cpu.c.patch
+++ b/llama.cpp.patches/patches/ggml_src_ggml-cpu_ggml-cpu.c.patch
@@ -1,0 +1,55 @@
+diff --git a/ggml/src/ggml-cpu/ggml-cpu.c b/ggml/src/ggml-cpu/ggml-cpu.c
+--- a/llama.cpp/ggml/src/ggml-cpu/ggml-cpu.c
++++ b/llama.cpp/ggml/src/ggml-cpu/ggml-cpu.c
+@@ -1520,6 +1520,26 @@ static void ggml_compute_forward_mul_mat_id(
+     const struct ggml_tensor * src1 = dst->src[1];
+     const struct ggml_tensor * ids = dst->src[2];
+ 
++#if GGML_USE_LLAMAFILE
++    // [jart] route MoE matmul through llamafile's batched MoE kernels
++    // when possible. Mirrors the dense-matmul llamafile_sgemm hook above.
++    // The full declarations live in /llamafile/sgemm.h but that header
++    // is shadowed inside the submodule by an upstream sgemm.h that only
++    // declares llamafile_sgemm; forward-declare here to keep the patch
++    // self-contained.
++    extern bool llamafile_mixmul(const struct ggml_compute_params *,
++                                 const struct ggml_tensor *,
++                                 const struct ggml_tensor *,
++                                 const struct ggml_tensor *,
++                                 struct ggml_tensor *);
++    extern bool llamafile_mixmul_iqk(long, long, long, int, int,
++                                     const void *, const void *, float *,
++                                     long, long, const void *, int, int);
++    if (llamafile_mixmul(params, src0, src1, ids, dst)) {
++        return;
++    }
++#endif
++
+     GGML_TENSOR_BINARY_OP_LOCALS
+ 
+     const int ith = params->ith;
+@@ -1639,6 +1659,24 @@ static void ggml_compute_forward_mul_mat_id(
+         const int64_t nr0 = ne01;
+         const int64_t nr1 = cne1;
+ 
++#if GGML_USE_LLAMAFILE
++        // [jart] inner hook for K-quant/Q8 MoE matmul, mirrors 0.9.3
++        // ggml.c:11360. Catches the cases the top-level llamafile_mixmul
++        // doesn't claim (notably Q4_K/Q5_K/Q6_K weights with Q8_K vec_dot).
++        if ((vec_dot_type == GGML_TYPE_Q8_K || vec_dot_type == GGML_TYPE_Q8_0 ||
++             vec_dot_type == GGML_TYPE_Q8_1) &&
++            dst->type == GGML_TYPE_F32 && ne13 == 1) {
++            if (llamafile_mixmul_iqk(nr0, nr1, ne00, ne11, src0->type,
++                                     (const char *)src0_cur,
++                                     (const char *)wdata,
++                                     (float *)dst->data, nb1, nb2,
++                                     matrix_rows + cur_a*ids->ne[0]*ids->ne[1],
++                                     ith, nth)) {
++                continue;
++            }
++        }
++#endif
++
+         int chunk_size = 16;
+         if (nr0 == 1 || nr1 == 1) {
+             chunk_size = 64;

--- a/llama.cpp.patches/patches/ggml_src_ggml-cpu_ggml-cpu.c.patch
+++ b/llama.cpp.patches/patches/ggml_src_ggml-cpu_ggml-cpu.c.patch
@@ -1,6 +1,7 @@
 diff --git a/ggml/src/ggml-cpu/ggml-cpu.c b/ggml/src/ggml-cpu/ggml-cpu.c
---- a/llama.cpp/ggml/src/ggml-cpu/ggml-cpu.c
-+++ b/llama.cpp/ggml/src/ggml-cpu/ggml-cpu.c
+index 2b3eb5b5c..cca917fd2 100644
+--- a/ggml/src/ggml-cpu/ggml-cpu.c
++++ b/ggml/src/ggml-cpu/ggml-cpu.c
 @@ -1520,6 +1520,26 @@ static void ggml_compute_forward_mul_mat_id(
      const struct ggml_tensor * src1 = dst->src[1];
      const struct ggml_tensor * ids = dst->src[2];
@@ -53,3 +54,23 @@ diff --git a/ggml/src/ggml-cpu/ggml-cpu.c b/ggml/src/ggml-cpu/ggml-cpu.c
          int chunk_size = 16;
          if (nr0 == 1 || nr1 == 1) {
              chunk_size = 64;
+@@ -2827,6 +2865,19 @@ struct ggml_cplan ggml_graph_plan(
+                         cur += n_as*ids->ne[0]*ids->ne[1]*sizeof(struct mmid_row_mapping) + sizeof(int64_t);
+                         // atomic_current_chunk
+                         cur += CACHE_LINE_SIZE*n_as + CACHE_LINE_SIZE;
++#if GGML_USE_LLAMAFILE
++                        // [jart] reserve work-buffer space for llamafile_mixmul.
++                        // Without this, MixMul::allocate_shared_memory() in
++                        // tinyblas_cpu_mixmul.inc may fail (returns nullptr from
++                        // allocate() when toto > params->wsize), causing the
++                        // outer llamafile_mixmul() hook in mul_mat_id to silently
++                        // return false. Mirrors 0.9.3 ggml.c:17531.
++                        extern size_t llamafile_mixmul_needs(const struct ggml_tensor *,
++                                                              const struct ggml_tensor *,
++                                                              const struct ggml_tensor *);
++                        size_t cur2 = llamafile_mixmul_needs(src0, src1, ids);
++                        if (cur2 > cur) cur = cur2;
++#endif
+                     } break;
+                 case GGML_OP_OUT_PROD:
+                     {

--- a/llama.cpp.patches/patches/ggml_src_ggml-cpu_ggml-cpu.c.patch
+++ b/llama.cpp.patches/patches/ggml_src_ggml-cpu_ggml-cpu.c.patch
@@ -1,7 +1,6 @@
 diff --git a/ggml/src/ggml-cpu/ggml-cpu.c b/ggml/src/ggml-cpu/ggml-cpu.c
-index 2b3eb5b5c..cca917fd2 100644
---- a/ggml/src/ggml-cpu/ggml-cpu.c
-+++ b/ggml/src/ggml-cpu/ggml-cpu.c
+--- a/llama.cpp/ggml/src/ggml-cpu/ggml-cpu.c
++++ b/llama.cpp/ggml/src/ggml-cpu/ggml-cpu.c
 @@ -1520,6 +1520,26 @@ static void ggml_compute_forward_mul_mat_id(
      const struct ggml_tensor * src1 = dst->src[1];
      const struct ggml_tensor * ids = dst->src[2];


### PR DESCRIPTION
## Summary

The 0.10.0 "llamafile reloaded" refactor (#867) dropped the `llamafile_mixmul` and `llamafile_mixmul_iqk` hooks from `ggml_compute_forward_mul_mat_id` in the llama.cpp submodule. Since then, MoE matmul on x86 falls through to single-row `ggml_vec_dot_q4_K_q8_K` (AVX2-only, no batching) instead of llamafile's batched, AVX-512-aware iqk kernels. This causes the **5–15× CPU-only regression on K-quant MoE models** reported in #973 (Qwen3-30B-A3B-Q4_K_M reproduces cleanly on both Alderlake AVX-VNNI and Ice Lake-SP AVX-512-VNNI — it's an x86-wide bug, not AVX-VNNI-specific).

This PR adds a new patch `llama.cpp.patches/patches/ggml_src_ggml-cpu_ggml-cpu.c.patch` that re-introduces both hooks (top-level `llamafile_mixmul` + inner `llamafile_mixmul_iqk`), mirroring the 0.9.3 shape. The fix applies cleanly to both the 0.10.1 submodule pin (`5e9c63546`) and `main`'s newer pin (`7b8443ac7`) — context at the patch sites is byte-identical.

## Evidence (Xeon Gold 6338, Ice Lake-SP, Qwen3-30B-A3B-Q4_K_M, CPU-only)

| metric | 0.9.3 | 0.10.1 unpatched | **0.10.1 + this PR** |
|---|---:|---:|---:|
| pp2048 (t/s) | 128.69 | 8.47 | **27.93** (3.3× speedup) |
| tg32 (t/s) | 20.12 | 3.42 | **4.61** (1.35× speedup) |

perf-record confirms the hook is firing: `ggml_vec_dot_q4_K_q8_K` (57% of cycles unpatched) drops below the 0.05% threshold in the patched profile, while `mul_mat_qX_K_q8_K_T<DequantizerQ4K,1>` (the iqk kernel) climbs from 5.89% to 23.34%.

## Why we don't recover the full 15× yet — confirmed: flash-attn

After the matmul fix, the new top symbol is `ggml_compute_forward_flash_attn_ext_f16_one_chunk` at ~28% of cycles, with `ggml_compute_fp32_to_fp16` and `ggml_vec_mad_f16` as inlined hot children. 0.9.3 doesn't use this code path at all (predates upstream's flash-attn-ext). Confirmed via direct experiment ([details](https://github.com/mozilla-ai/llamafile/pull/974#issuecomment-4518466411)): adding `-fa off` to the patched build recovers **84% of 0.9.3 pp** and **82% of 0.9.3 tg** on the Qwen3 MoE reproducer, and **83% / 85%** on dense Llama-3.1-8B. The perf profile in that configuration is structurally identical to 0.9.3's.

So the full picture of issue #973 is two stacked, independent regressions:

| | recovered by this PR alone | recovered by `-fa off` alone | recovered by both |
|---|---:|---:|---:|
| Qwen3-30B-A3B-Q4_K_M (MoE) pp | 22% | 8.5% | **84%** |
| Qwen3-30B-A3B-Q4_K_M (MoE) tg | 23% | 34% | **82%** |
| Llama-3.1-8B-Q4_K_M (dense) pp | 40% (no change) | n/a (same effect alone) | **83%** |

This PR fixes the MoE matmul leg. The flash-attn leg should be a separate PR — short-term option is flipping the default of `-fa` from `auto`→`off` for CPU-only inference; long-term option is fixing the f16 mad-loop or landing a llamafile-specific FA implementation.

## Full investigation write-up

Self-contained gist with the issue background, root cause analysis, perf-record evidence (including bucketed before/after tables for both kernels and threading), patch design notes, the second-regression finding, and follow-ups:

https://gist.github.com/aittalam/de0f8a494ff17d38c100f7ad08c0d7da

Refs #973 (partial fix — the matmul leg only; the flash-attn leg is being tracked separately and should NOT be auto-closed by this merge).

## Test plan

- [x] `.cosmocc/4.0.2/bin/make -j32` clean build with patch applied
- [x] `.cosmocc/4.0.2/bin/make check` passes (19/19 `extract_data_uris` tests)
- [x] Coherence test against Qwen3-30B-A3B-Q4_K_M (model generates correctly, including `reasoning_content`)
- [x] llama-benchy pp2048/tg32 confirms speedup
- [x] perf-record confirms `ggml_vec_dot_q4_K_q8_K` disappears from hot path and iqk kernels replace it
- [x] Sanity-bench a dense model (Llama-3.1-8B-Instruct-Q4_K_M) on 0.9.3 vs 0.10.1 stock vs patched: patched is within noise of stock 0.10.1 (+1.6% pp / +1.8% tg) — no regression. Three-way comparison also shows a separate ~2.5× dense regression in 0.10.x vs 0.9.3 that this PR does NOT address (and shouldn't — it's almost certainly the flash-attn f16 path mentioned above). See [three-way comparison comment](https://github.com/mozilla-ai/llamafile/pull/974#issuecomment-4518139789).
- [x] Sanity-bench a Q8_0 MoE (Qwen3-30B-A3B-Q8_0, same family as the reproducer): smoke-test passes, +54% pp with `-fa off`, no tg change, no regression; perf confirms the top-level `llamafile_mixmul → MixMul → tinyBLAS_Q0_AVX2` path is the one firing (different code path from the Q4_K_M inner-hook path). See [Q8_0 bench comment](https://github.com/mozilla-ai/llamafile/pull/974#issuecomment-4519839446).
- [x] ARM Mac sanity — Apple M4 Max (macOS 26.4.1, 16 cores), Qwen3-30B-A3B-Q4_K_M, CPU-only `-fa off`: smoke generation coherent, patch effect at matched threads (-t 12) is +163% pp / +19% tg, patched recovers 93% of 0.9.3 pp and 81% of tg. cosmocc's aarch64 baseline doesn't set `__ARM_FEATURE_SVE`/`__ARM_FEATURE_MATMUL_INT8`, so hooks fire on Apple Silicon too. See [Mac M4 Max bench comment](https://github.com/mozilla-ai/llamafile/pull/974#issuecomment-4520147405).

All test-plan items checked. Ready for review when maintainers are ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)