### PR TITLE
common.cpp: fix Apple Silicon physical-core detection under cosmocc (#976)

### DIFF
--- a/llama.cpp.patches/patches/common_common.cpp.patch
+++ b/llama.cpp.patches/patches/common_common.cpp.patch
@@ -1,7 +1,58 @@
 diff --git a/common/common.cpp b/common/common.cpp
 --- a/llama.cpp/common/common.cpp
 +++ b/llama.cpp/common/common.cpp
-@@ -972,6 +972,16 @@ std::string fs_get_cache_directory() {
+@@ -33,6 +33,10 @@
+ #include <sys/sysctl.h>
+ #endif
+ 
++#if defined(COSMOCC)
++#include <cosmo.h> // for IsLinux() and sysctlbyname() declarations
++#endif
++
+ #if defined(_WIN32)
+ #define WIN32_LEAN_AND_MEAN
+ #ifndef NOMINMAX
+@@ -71,7 +75,38 @@ common_time_meas::~common_time_meas() {
+ //
+ 
+ int32_t common_cpu_get_num_physical_cores() {
+-#ifdef __linux__
++#if defined(COSMOCC)
++    // cosmocc cross-compiles for both Linux and macOS at once, so neither
++    // __linux__ nor __APPLE__ is defined here; detect the host OS at runtime.
++    if (IsLinux()) {
++        std::unordered_set<std::string> siblings;
++        for (uint32_t cpu=0; cpu < UINT32_MAX; ++cpu) {
++            std::ifstream thread_siblings("/sys/devices/system/cpu/cpu"
++                + std::to_string(cpu) + "/topology/thread_siblings");
++            if (!thread_siblings.is_open()) {
++                break; // no more cpus
++            }
++            std::string line;
++            if (std::getline(thread_siblings, line)) {
++                siblings.insert(line);
++            }
++        }
++        if (!siblings.empty()) {
++            return static_cast<int32_t>(siblings.size());
++        }
++    } else {
++        int32_t num_physical_cores;
++        size_t len = sizeof(num_physical_cores);
++        int result = sysctlbyname("hw.perflevel0.physicalcpu", &num_physical_cores, &len, NULL, 0);
++        if (result == 0) {
++            return num_physical_cores;
++        }
++        result = sysctlbyname("hw.physicalcpu", &num_physical_cores, &len, NULL, 0);
++        if (result == 0) {
++            return num_physical_cores;
++        }
++    }
++#elif defined(__linux__)
+     // enumerate the set of thread siblings, num entries is num cores
+     std::unordered_set<std::string> siblings;
+     for (uint32_t cpu=0; cpu < UINT32_MAX; ++cpu) {
+@@ -972,6 +1007,16 @@ std::string fs_get_cache_directory() {
          cache_directory = std::getenv("HOME") + std::string("/Library/Caches/");
  #elif defined(_WIN32)
          cache_directory = std::getenv("LOCALAPPDATA");
@@ -18,7 +69,7 @@ diff --git a/common/common.cpp b/common/common.cpp
  #elif defined(__EMSCRIPTEN__)
          GGML_ABORT("not implemented on this platform");
  #else
-@@ -1148,10 +1158,31 @@ common_init_result::common_init_result(common_params & params) :
+@@ -1148,10 +1193,31 @@ common_init_result::common_init_result(common_params & params) :
  
      if (params.fit_params) {
          LOG_INF("%s: fitting params to device memory, for bugs during this step try to reproduce them with -fit off, or provide --verbose logs if the bug only occurs with -fit on\n", __func__);


### PR DESCRIPTION
## Summary

Fixes #976. On Apple Silicon, llamafile 0.10.x defaulted to **8 CPU threads** on a 12-P-core / 4-E-core M4 Max where 0.9.3 used **12**.

Upstream `common_cpu_get_num_physical_cores()` picks its per-OS implementation with `#ifdef __linux__ / #elif defined(__APPLE__)`. Under cosmocc neither macro is defined at compile time (the binary targets both OSes at runtime), so both branches were skipped and the function fell through to `hardware_concurrency() / 2` → 16/2 = 8 on M4 Max.

Add a `COSMOCC` branch that runtime-detects the host OS via Cosmopolitan's `IsLinux()` helper and runs the matching code path (`/sys/...thread_siblings` on Linux, `sysctlbyname("hw.perflevel0.physicalcpu", ...)` then `"hw.physicalcpu"` on macOS). Native-toolchain builds are unaffected — the `COSMOCC` define only exists in the llamafile build (`llama.cpp.patches/llamafile-files/BUILD.mk`).

This is the Apple-Silicon-specific leg of the 0.10.x regression. Independent of #974 (matmul) and #975 (flash-attn) and stacks on top of them.

## Test plan

- [x] `make setup` reapplies patches cleanly on a fresh checkout
- [x] `llamafile:build` succeeds
- [x] `llamafile:check` passes (extract_data_uris tests)
- [x] Linux x86_64 (Xeon, 16P/32T): banner shows `n_threads = 16` (unchanged — `IsLinux()` true → `/sys/...` path)
- [x] macOS arm64 (M4 Max, 12P/4E/16T): banner shows `n_threads = 12` (was 8 before the fix)
- [x] Brief inference smoke test on macOS (Qwen3-0.6B) produces expected output

🤖 Generated with [Claude Code](https://claude.com/claude-code)