### PR TITLE
vulkan: clearer message when --gpu vulkan is explicitly unavailable

### DIFF
--- a/llamafile/vulkan.c
+++ b/llamafile/vulkan.c
@@ -100,8 +100,17 @@ static void ImportVulkan(void) {
         int count = gpu_call_device_count(g_vulkan.get_device_count);
         llamafile_info("vulkan", "found %d GPU device(s)", count);
     } else if (FLAG_gpu == LLAMAFILE_GPU_VULKAN) {
-        fprintf(stderr, "fatal error: support for --gpu vulkan was explicitly requested, "
-                "but it wasn't available\n");
+        // Vulkan was explicitly requested but the probe found no usable device
+        // (or the driver faulted during probe and was skipped to keep the
+        // process alive -- see gpu_backend.c). Fail loudly rather than
+        // silently downgrade, but tell the user how to proceed.
+        fprintf(stderr,
+                "fatal error: --gpu vulkan was explicitly requested but Vulkan is not "
+                "usable on this system\n"
+                "  - no Vulkan-capable device was detected, or the driver "
+                "failed/crashed during probe and was skipped for safety\n"
+                "  - retry with --gpu auto to use the best available backend "
+                "(falls back to CPU), or --gpu disabled to force CPU\n");
         exit(1);
     }
 }


### PR DESCRIPTION
## What

When Vulkan is **explicitly** requested (`--gpu vulkan`) but no usable device is found, llamafile already exits with a fatal error instead of silently downgrading to CPU. This keeps that behavior (a silent downgrade would surprise users with ~10× slower inference on an explicit GPU request) but replaces the dead-end message:

```
fatal error: support for --gpu vulkan was explicitly requested, but it wasn't available
```

with an actionable one that names the two real causes and the way forward:

```
fatal error: --gpu vulkan was explicitly requested but Vulkan is not usable on this system
  - no Vulkan-capable device was detected, or the driver failed/crashed during probe and was skipped for safety
  - retry with --gpu auto to use the best available backend (falls back to CPU), or --gpu disabled to force CPU
```

## Why

The "driver failed/crashed during probe and was skipped" case is real on some Windows configurations (e.g. certain Intel iGPU setups, issue #938), where the out-of-process probe / crash guard (#988) correctly skips a faulting backend so the process stays alive. In `--gpu auto` that already falls back to CPU silently and correctly; only the explicit-request path surfaced a message that left users with no next step.

## Scope

- Messaging only — **no behavior change**. `--gpu auto` fallback and the `exit(1)` on explicit request are unchanged.
- Touches `llamafile/vulkan.c` only (11 lines). The sibling `cuda.c`/`metal.c` messages could get the same treatment in a follow-up if desired.
- Compiles clean under cosmocc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)