### PR TITLE
Add support for Jinja-based tool calling (MiniCPM5 and other recent models).

### DIFF
--- a/llama.cpp.patches/README.md
+++ b/llama.cpp.patches/README.md
@@ -205,6 +205,7 @@ can change on a llama.cpp bump — when it does, the asset list in
 | `ggml_src_ggml-vulkan_ggml-vulkan.cpp.patch` | Fixes unsigned integer underflow in `ggml_backend_vk_get_device_memory` where Vulkan's `heapUsage` can exceed `heapBudget` (clamps to zero instead of wrapping) |
 | `src_models_t5.cpp.patch` | Forward-declares the `graph<false>`/`graph<true>` explicit specializations before `build_arch_graph` so clang's `-std=gnu++23` doesn't reject them as specializations after implicit instantiation |
 | `src_models_eagle3.cpp.patch` | Moves `build_arch_graph` to the end of the file, after the `graph<true>`/`graph<false>` constructor specializations, so clang's `-std=gnu++23` doesn't reject them as explicit specializations appearing after the `make_unique<graph<...>>` implicit instantiation point |
+| `src_models_dflash.cpp.patch` | Same cosmocc/clang `build_arch_graph` ordering fix as `eagle3` for the new DFlash draft model |
 
 ## Creating New Patches
 

--- a/llama.cpp.patches/llamafile-files/BUILD.mk
+++ b/llama.cpp.patches/llamafile-files/BUILD.mk
@@ -79,6 +79,7 @@ LLAMA_SRCS_CPP := \
 	llama.cpp/src/models/delta-net-base.cpp \
 	llama.cpp/src/models/dots1.cpp \
 	llama.cpp/src/models/dream.cpp \
+	llama.cpp/src/models/dflash.cpp \
 	llama.cpp/src/models/eagle3.cpp \
 	llama.cpp/src/models/ernie4-5-moe.cpp \
 	llama.cpp/src/models/ernie4-5.cpp \
@@ -240,7 +241,6 @@ COMMON_SRCS_CPP := \
 	llama.cpp/common/jinja/runtime.cpp \
 	llama.cpp/common/jinja/string.cpp \
 	llama.cpp/common/jinja/value.cpp \
-	llama.cpp/common/json-partial.cpp \
 	llama.cpp/common/json-schema-to-grammar.cpp \
 	llama.cpp/common/license.cpp \
 	llama.cpp/common/llguidance.cpp \
@@ -420,6 +420,7 @@ TOOL_SERVER_SRCS := \
 	llama.cpp/tools/server/server-models.cpp \
 	llama.cpp/tools/server/server-queue.cpp \
 	llama.cpp/tools/server/server-schema.cpp \
+	llama.cpp/tools/server/server-stream.cpp \
 	llama.cpp/tools/server/server-task.cpp \
 	llama.cpp/tools/server/server-tools.cpp
 

--- a/llama.cpp.patches/patches/common_common.cpp.patch
+++ b/llama.cpp.patches/patches/common_common.cpp.patch
@@ -71,8 +71,8 @@ diff --git a/common/common.cpp b/common/common.cpp
  #else
 @@ -1201,10 +1246,31 @@ common_init_result::common_init_result(common_params & params, bool model_only)
      if (params.fit_params) {
-         LOG_INF("%s: fitting params to device memory ...\n", __func__);
-         LOG_INF("%s: (for bugs during this step try to reproduce them with -fit off, or provide --verbose logs if the bug only occurs with -fit on)\n", __func__);
+         COM_TRC("%s", "fitting params to device memory ...\n");
+         COM_TRC("%s", "(for bugs during this step try to reproduce them with -fit off, or provide --verbose logs if the bug only occurs with -fit on)\n");
 +
 +        // if a multimodal projection model is specified and will be loaded on GPU,
 +        // add its estimated size to the fit margins so the fit leaves enough room for it

--- a/llama.cpp.patches/patches/ggml_src_ggml-backend.cpp.patch
+++ b/llama.cpp.patches/patches/ggml_src_ggml-backend.cpp.patch
@@ -43,7 +43,7 @@ diff --git a/ggml/src/ggml-backend.cpp b/ggml/src/ggml-backend.cpp
  };
  
  ggml_backend_buffer_t ggml_backend_multi_buffer_alloc_buffer(ggml_backend_buffer_t * buffers, size_t n_buffers) {
-@@ -2210,7 +2218,7 @@ bool ggml_backend_compare_graph_backend(ggml_backend_t backend1, ggml_backend_t
+@@ -2214,7 +2222,7 @@ bool ggml_backend_compare_graph_backend(ggml_backend_t backend1, ggml_backend_t
  
  // CPU backend - buffer
  
@@ -52,7 +52,7 @@ diff --git a/ggml/src/ggml-backend.cpp b/ggml/src/ggml-backend.cpp
      GGML_ASSERT(buffer);
      uintptr_t data = (uintptr_t)buffer->context;
  
-@@ -2222,33 +2230,33 @@ static void * ggml_backend_cpu_buffer_get_base(ggml_backend_buffer_t buffer) {
+@@ -2226,33 +2234,33 @@ static void * ggml_backend_cpu_buffer_get_base(ggml_backend_buffer_t buffer) {
      return (void *)data;
  }
  
@@ -91,7 +91,7 @@ diff --git a/ggml/src/ggml-backend.cpp b/ggml/src/ggml-backend.cpp
      GGML_ASSERT(src);
      if (ggml_backend_buffer_is_host(src->buffer)) {
          memcpy(dst->data, src->data, ggml_nbytes(src));
-@@ -2259,7 +2267,7 @@ static bool ggml_backend_cpu_buffer_cpy_tensor(ggml_backend_buffer_t buffer, con
+@@ -2263,7 +2271,7 @@ static bool ggml_backend_cpu_buffer_cpy_tensor(ggml_backend_buffer_t buffer, con
      GGML_UNUSED(buffer);
  }
  
@@ -100,7 +100,7 @@ diff --git a/ggml/src/ggml-backend.cpp b/ggml/src/ggml-backend.cpp
      GGML_ASSERT(buffer);
      memset(buffer->context, value, buffer->size);
  }
-@@ -2276,6 +2284,7 @@ static const struct ggml_backend_buffer_i ggml_backend_cpu_buffer_i = {
+@@ -2280,6 +2288,7 @@ static const struct ggml_backend_buffer_i ggml_backend_cpu_buffer_i = {
      /* .cpy_tensor      = */ ggml_backend_cpu_buffer_cpy_tensor,
      /* .clear           = */ ggml_backend_cpu_buffer_clear,
      /* .reset           = */ NULL,
@@ -108,7 +108,7 @@ diff --git a/ggml/src/ggml-backend.cpp b/ggml/src/ggml-backend.cpp
  };
  
  static const struct ggml_backend_buffer_i ggml_backend_cpu_buffer_from_ptr_i = {
-@@ -2290,19 +2299,20 @@ static const struct ggml_backend_buffer_i ggml_backend_cpu_buffer_from_ptr_i = {
+@@ -2294,19 +2303,20 @@ static const struct ggml_backend_buffer_i ggml_backend_cpu_buffer_from_ptr_i = {
      /* .cpy_tensor      = */ ggml_backend_cpu_buffer_cpy_tensor,
      /* .clear           = */ ggml_backend_cpu_buffer_clear,
      /* .reset           = */ NULL,
@@ -131,7 +131,7 @@ diff --git a/ggml/src/ggml-backend.cpp b/ggml/src/ggml-backend.cpp
      void * data = ggml_aligned_malloc(size);
  
      if (data == NULL) {
-@@ -2313,13 +2323,13 @@ static ggml_backend_buffer_t ggml_backend_cpu_buffer_type_alloc_buffer(ggml_back
+@@ -2317,13 +2327,13 @@ static ggml_backend_buffer_t ggml_backend_cpu_buffer_type_alloc_buffer(ggml_back
      return ggml_backend_buffer_init(buft, ggml_backend_cpu_buffer_i, data, size);
  }
  
@@ -147,7 +147,7 @@ diff --git a/ggml/src/ggml-backend.cpp b/ggml/src/ggml-backend.cpp
      return true;
  
      GGML_UNUSED(buft);
-@@ -2342,7 +2352,7 @@ ggml_backend_buffer_type_t ggml_backend_cpu_buffer_type(void) {
+@@ -2346,7 +2356,7 @@ ggml_backend_buffer_type_t ggml_backend_cpu_buffer_type(void) {
      return &ggml_backend_cpu_buffer_type;
  }
  

--- a/llama.cpp.patches/patches/ggml_src_ggml-cpu_ops.cpp.patch
+++ b/llama.cpp.patches/patches/ggml_src_ggml-cpu_ops.cpp.patch
@@ -20,7 +20,7 @@ diff --git a/ggml/src/ggml-cpu/ops.cpp b/ggml/src/ggml-cpu/ops.cpp
  // ggml_compute_forward_dup
  
  static void ggml_compute_forward_dup_same_cont(
-@@ -8399,6 +8411,15 @@ static void ggml_compute_forward_flash_attn_ext_f16_one_chunk(
+@@ -8426,6 +8438,15 @@ static void ggml_compute_forward_flash_attn_ext_f16_one_chunk(
      GGML_ASSERT((                            q_to_vec_dot) && "fattn: unsupported K-type");
      GGML_ASSERT((v->type == GGML_TYPE_F32 || v_to_float  ) && "fattn: unsupported V-type");
  
@@ -36,7 +36,7 @@ diff --git a/ggml/src/ggml-cpu/ops.cpp b/ggml/src/ggml-cpu/ops.cpp
      int ith = params->ith;
  
      for (int ir = ir0; ir < ir1; ++ir) {
-@@ -8418,10 +8439,22 @@ static void ggml_compute_forward_flash_attn_ext_f16_one_chunk(
+@@ -8445,10 +8466,22 @@ static void ggml_compute_forward_flash_attn_ext_f16_one_chunk(
          ggml_fp16_t * VKQ16 = (ggml_fp16_t *) (VKQ32 + 1*DV); // (temporary) FP16 VKQ accumulator
          ggml_fp16_t * Q_q   = (ggml_fp16_t *) (VKQ32 + 2*DV); // (temporary) buffer for Q converted to quantized/FP16
  
@@ -62,7 +62,7 @@ diff --git a/ggml/src/ggml-cpu/ops.cpp b/ggml/src/ggml-cpu/ops.cpp
          }
  
          const ggml_fp16_t * mp = mask ? (ggml_fp16_t *)((char *) mask->data + iq1*mask->nb[1] + (iq2%mask->ne[2])*mask->nb[2] + (iq3%mask->ne[3])*mask->nb[3]) : NULL;
-@@ -8450,7 +8483,13 @@ static void ggml_compute_forward_flash_attn_ext_f16_one_chunk(
+@@ -8477,7 +8510,13 @@ static void ggml_compute_forward_flash_attn_ext_f16_one_chunk(
              float s; // KQ value
  
              const char * k_data = (const char *) k->data + ( ic*nbk1 + ik2*nbk2 + ik3*nbk3);
@@ -76,7 +76,7 @@ diff --git a/ggml/src/ggml-cpu/ops.cpp b/ggml/src/ggml-cpu/ops.cpp
  
              s = s*scale; // scale KQ value
  
-@@ -8467,21 +8506,36 @@ static void ggml_compute_forward_flash_attn_ext_f16_one_chunk(
+@@ -8494,21 +8533,36 @@ static void ggml_compute_forward_flash_attn_ext_f16_one_chunk(
  
              const char * v_data = ((const char *) v->data + (ic*nbv1 + iv2*nbv2 + iv3*nbv3));
  
@@ -116,7 +116,7 @@ diff --git a/ggml/src/ggml-cpu/ops.cpp b/ggml/src/ggml-cpu/ops.cpp
              } else {
                  if (s > M) {
                      // s is new maximum, ms < 1.0f, vs == expf(s - s) == 1.0f
-@@ -8489,26 +8543,20 @@ static void ggml_compute_forward_flash_attn_ext_f16_one_chunk(
+@@ -8516,26 +8570,20 @@ static void ggml_compute_forward_flash_attn_ext_f16_one_chunk(
                      ms = expf(Mold - M);
  
                      // V = V*expf(Mold - M)
@@ -146,7 +146,7 @@ diff --git a/ggml/src/ggml-cpu/ops.cpp b/ggml/src/ggml-cpu/ops.cpp
              for (int64_t d = 0; d < DV; ++d) {
                  VKQ32[d] = GGML_CPU_FP16_TO_FP32(VKQ16[d]);
              }
-@@ -8729,8 +8777,24 @@ static void ggml_compute_forward_flash_attn_ext_tiled(
+@@ -8756,8 +8804,24 @@ static void ggml_compute_forward_flash_attn_ext_tiled(
                  const char * k_data = (const char *)k->data + (ic + tk)*nbk1 + ik2*nbk2 + ik3*nbk3;
                  if (kv_type == GGML_TYPE_F16) {
                      const ggml_fp16_t * k_f16 = (const ggml_fp16_t *)k_data;
@@ -173,7 +173,7 @@ diff --git a/ggml/src/ggml-cpu/ops.cpp b/ggml/src/ggml-cpu/ops.cpp
                      }
                  } else {
                      const float * k_f32_src = (const float *)k_data;
-@@ -8740,7 +8804,18 @@ static void ggml_compute_forward_flash_attn_ext_tiled(
+@@ -8767,7 +8831,18 @@ static void ggml_compute_forward_flash_attn_ext_tiled(
                  }
              }
              memset(KQ, 0, Q_TILE_SZ * KV_TILE_SZ * sizeof(float));
@@ -192,7 +192,7 @@ diff --git a/ggml/src/ggml-cpu/ops.cpp b/ggml/src/ggml-cpu/ops.cpp
              ggml_vec_scale_f32(Q_TILE_SZ * KV_TILE_SZ, KQ, scale);
  
              // Set padded KQ entries to -inf so softmax gives them zero weight
-@@ -8793,7 +8868,15 @@ static void ggml_compute_forward_flash_attn_ext_tiled(
+@@ -8820,7 +8895,15 @@ static void ggml_compute_forward_flash_attn_ext_tiled(
              for (int tk = 0; tk < kv_tile; tk++) {
                  const char * v_data = (const char *)v->data + (ic + tk)*nbv1 + iv2*nbv2 + iv3*nbv3;
                  if (kv_type == GGML_TYPE_F16) {
@@ -208,7 +208,7 @@ diff --git a/ggml/src/ggml-cpu/ops.cpp b/ggml/src/ggml-cpu/ops.cpp
                  } else {
                      memcpy(V32 + tk * DV, v_data, DV * sizeof(float));
                  }
-@@ -8803,7 +8886,16 @@ static void ggml_compute_forward_flash_attn_ext_tiled(
+@@ -8830,7 +8913,16 @@ static void ggml_compute_forward_flash_attn_ext_tiled(
                      memset(KQ + tq * KV_TILE_SZ, 0, KV_TILE_SZ * sizeof(float));
                  }
              }

--- a/llama.cpp.patches/patches/ggml_src_ggml-cuda_cpy.cu.patch
+++ b/llama.cpp.patches/patches/ggml_src_ggml-cuda_cpy.cu.patch
@@ -1,7 +1,7 @@
 diff --git a/ggml/src/ggml-cuda/cpy.cu b/ggml/src/ggml-cuda/cpy.cu
 --- a/llama.cpp/ggml/src/ggml-cuda/cpy.cu
 +++ b/llama.cpp/ggml/src/ggml-cuda/cpy.cu
-@@ -368,6 +368,7 @@ static void ggml_cpy_q5_1_f32_cuda(
+@@ -374,6 +374,7 @@ static void ggml_cpy_q5_1_f32_cuda(
          ne10, ne11, ne12, nb10, nb11, nb12, nb13);
  }
  
@@ -9,15 +9,15 @@ diff --git a/ggml/src/ggml-cuda/cpy.cu b/ggml/src/ggml-cuda/cpy.cu
  static void ggml_cpy_f32_iq4_nl_cuda(
      const char * cx, char * cdst, const int64_t ne,
      const int64_t ne00, const int64_t ne01, const int64_t ne02, const int64_t nb00, const int64_t nb01, const int64_t nb02,
-@@ -379,6 +380,7 @@ static void ggml_cpy_f32_iq4_nl_cuda(
+@@ -385,6 +386,7 @@ static void ggml_cpy_f32_iq4_nl_cuda(
      cpy_f32_q<cpy_blck_f32_iq4_nl, QK4_NL><<<num_blocks, 1, 0, stream>>>
          (cx, cdst, ne, ne00, ne01, ne02, nb00, nb01, nb02, nb03, ne10, ne11, ne12, nb10, nb11, nb12, nb13);
  }
 +#endif // GGML_CUDA_NO_IQ_QUANTS
  
- void ggml_cuda_cpy(ggml_backend_cuda_context & ctx, const ggml_tensor * src0, ggml_tensor * src1) {
-     const int64_t ne = ggml_nelements(src0);
-@@ -473,9 +475,11 @@ void ggml_cuda_cpy(ggml_backend_cuda_context & ctx, const ggml_tensor * src0, gg
+ // check if a same-type copy reduces to a 2D strided copy (height rows of width
+ // contiguous bytes), so it can use cudaMemcpy2DAsync instead of the scalar kernel
+@@ -524,9 +526,11 @@ void ggml_cuda_cpy(ggml_backend_cuda_context & ctx, const ggml_tensor * src0, gg
      } else if (src0->type == GGML_TYPE_Q5_0 && src1->type == GGML_TYPE_F32) {
          ggml_cpy_q5_0_f32_cuda
                  (src0_ddc, src1_ddc, ne, ne00, ne01, ne02, nb00, nb01, nb02, nb03, ne10, ne11, ne12, nb10, nb11, nb12, nb13, main_stream);

--- a/llama.cpp.patches/patches/ggml_src_ggml-cuda_ggml-cuda.cu.patch
+++ b/llama.cpp.patches/patches/ggml_src_ggml-cuda_ggml-cuda.cu.patch
@@ -372,7 +372,7 @@ diff --git a/ggml/src/ggml-cuda/ggml-cuda.cu b/ggml/src/ggml-cuda/ggml-cuda.cu
      ggml_backend_buffer_t buf_src = src->view_src ? src->view_src->buffer : src->buffer;
      ggml_backend_buffer_t buf_dst = dst->view_src ? dst->view_src->buffer : dst->buffer;
  
-@@ -3243,7 +3266,7 @@ static bool ggml_backend_cuda_cpy_tensor_async(ggml_backend_t backend_src, ggml_
+@@ -3259,7 +3282,7 @@ static bool ggml_backend_cuda_cpy_tensor_async(ggml_backend_t backend_src, ggml_
      return true;
  }
  
@@ -381,7 +381,7 @@ diff --git a/ggml/src/ggml-cuda/ggml-cuda.cu b/ggml/src/ggml-cuda/ggml-cuda.cu
      ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *)backend->context;
  
      CUDA_CHECK(cudaStreamSynchronize(cuda_ctx->stream()));
-@@ -4465,7 +4488,7 @@ static bool ggml_cuda_graph_set_enabled(ggml_backend_cuda_context * cuda_ctx, co
+@@ -4481,7 +4504,7 @@ static bool ggml_cuda_graph_set_enabled(ggml_backend_cuda_context * cuda_ctx, co
  }
  #endif // USE_CUDA_GRAPH
  
@@ -390,7 +390,7 @@ diff --git a/ggml/src/ggml-cuda/ggml-cuda.cu b/ggml/src/ggml-cuda/ggml-cuda.cu
      ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *) backend->context;
  
      ggml_cuda_set_device(cuda_ctx->device);
-@@ -4524,13 +4547,13 @@ static enum ggml_status ggml_backend_cuda_graph_compute(ggml_backend_t backend,
+@@ -4540,13 +4563,13 @@ static enum ggml_status ggml_backend_cuda_graph_compute(ggml_backend_t backend,
      return GGML_STATUS_SUCCESS;
  }
  
@@ -406,7 +406,7 @@ diff --git a/ggml/src/ggml-cuda/ggml-cuda.cu b/ggml/src/ggml-cuda/ggml-cuda.cu
      ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *)backend->context;
  
      if (ggml_backend_is_cuda(backend)) {
-@@ -4549,7 +4572,7 @@ static void ggml_backend_cuda_event_wait(ggml_backend_t backend, ggml_backend_ev
+@@ -4565,7 +4588,7 @@ static void ggml_backend_cuda_event_wait(ggml_backend_t backend, ggml_backend_ev
      }
  }
  
@@ -415,7 +415,7 @@ diff --git a/ggml/src/ggml-cuda/ggml-cuda.cu b/ggml/src/ggml-cuda/ggml-cuda.cu
      ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *) backend->context;
  
  #ifdef USE_CUDA_GRAPH
-@@ -4837,7 +4860,7 @@ void ggml_backend_cuda_get_device_memory(int device, size_t * free, size_t * tot
+@@ -4853,7 +4876,7 @@ void ggml_backend_cuda_get_device_memory(int device, size_t * free, size_t * tot
      CUDA_CHECK(cudaMemGetInfo(free, total));
  }
  
@@ -424,7 +424,7 @@ diff --git a/ggml/src/ggml-cuda/ggml-cuda.cu b/ggml/src/ggml-cuda/ggml-cuda.cu
      if (getenv("GGML_CUDA_REGISTER_HOST") == nullptr) {
          return false;
      }
-@@ -4860,7 +4883,7 @@ bool ggml_backend_cuda_register_host_buffer(void * buffer, size_t size) {
+@@ -4876,7 +4899,7 @@ bool ggml_backend_cuda_register_host_buffer(void * buffer, size_t size) {
  #endif // CUDART_VERSION >= 11010 || defined(GGML_USE_MUSA)
  }
  
@@ -433,7 +433,7 @@ diff --git a/ggml/src/ggml-cuda/ggml-cuda.cu b/ggml/src/ggml-cuda/ggml-cuda.cu
      if (getenv("GGML_CUDA_REGISTER_HOST") == nullptr) {
          return;
      }
-@@ -4883,12 +4906,12 @@ struct ggml_backend_cuda_device_context {
+@@ -4899,12 +4922,12 @@ struct ggml_backend_cuda_device_context {
      int op_offload_min_batch_size;
  };
  
@@ -448,7 +448,7 @@ diff --git a/ggml/src/ggml-cuda/ggml-cuda.cu b/ggml/src/ggml-cuda/ggml-cuda.cu
      ggml_backend_cuda_device_context * ctx = (ggml_backend_cuda_device_context *)dev->context;
      return ctx->description.c_str();
  }
-@@ -4969,7 +4992,7 @@ static bool ggml_backend_cuda_get_available_uma_memory(long * available_memory_k
+@@ -4985,7 +5008,7 @@ static bool ggml_backend_cuda_get_available_uma_memory(long * available_memory_k
  }
  #endif // defined(__linux__)
  
@@ -457,7 +457,7 @@ diff --git a/ggml/src/ggml-cuda/ggml-cuda.cu b/ggml/src/ggml-cuda/ggml-cuda.cu
      ggml_backend_cuda_device_context * ctx = (ggml_backend_cuda_device_context *)dev->context;
      ggml_cuda_set_device(ctx->device);
      CUDA_CHECK(cudaMemGetInfo(free, total));
-@@ -4999,7 +5022,7 @@ static void ggml_backend_cuda_device_get_memory(ggml_backend_dev_t dev, size_t *
+@@ -5015,7 +5038,7 @@ static void ggml_backend_cuda_device_get_memory(ggml_backend_dev_t dev, size_t *
  
  }
  
@@ -466,7 +466,7 @@ diff --git a/ggml/src/ggml-cuda/ggml-cuda.cu b/ggml/src/ggml-cuda/ggml-cuda.cu
      ggml_backend_cuda_device_context * ctx = (ggml_backend_cuda_device_context *) dev->context;
  
      cudaDeviceProp prop;
-@@ -5010,7 +5033,7 @@ static enum ggml_backend_dev_type ggml_backend_cuda_device_get_type(ggml_backend
+@@ -5026,7 +5049,7 @@ static enum ggml_backend_dev_type ggml_backend_cuda_device_get_type(ggml_backend
          : GGML_BACKEND_DEVICE_TYPE_GPU;
  }
  
@@ -475,7 +475,7 @@ diff --git a/ggml/src/ggml-cuda/ggml-cuda.cu b/ggml/src/ggml-cuda/ggml-cuda.cu
      ggml_backend_cuda_device_context * ctx = (ggml_backend_cuda_device_context *)dev->context;
  
      props->name        = ggml_backend_cuda_device_get_name(dev);
-@@ -5034,24 +5057,24 @@ static void ggml_backend_cuda_device_get_props(ggml_backend_dev_t dev, ggml_back
+@@ -5050,24 +5073,24 @@ static void ggml_backend_cuda_device_get_props(ggml_backend_dev_t dev, ggml_back
      };
  }
  
@@ -504,7 +504,7 @@ diff --git a/ggml/src/ggml-cuda/ggml-cuda.cu b/ggml/src/ggml-cuda/ggml-cuda.cu
      ggml_backend_cuda_device_context * dev_ctx = (ggml_backend_cuda_device_context *) dev->context;
  
      // split buffers can only be used with GGML_OP_MUL_MAT
-@@ -5455,7 +5478,7 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
+@@ -5471,7 +5494,7 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
      }
  }
  
@@ -513,7 +513,7 @@ diff --git a/ggml/src/ggml-cuda/ggml-cuda.cu b/ggml/src/ggml-cuda/ggml-cuda.cu
      ggml_backend_cuda_device_context * dev_ctx = (ggml_backend_cuda_device_context *) dev->context;
      const bool integrated = ggml_cuda_info().devices[dev_ctx->device].integrated;
      return (((ggml_backend_buft_is_cuda(buft) || ggml_backend_buft_is_cuda_split(buft)) && buft->device == dev) || (integrated && ggml_backend_buft_is_cuda_host(buft)));
-@@ -5476,13 +5499,13 @@ static int64_t get_op_batch_size(const ggml_tensor * op) {
+@@ -5492,13 +5515,13 @@ static int64_t get_op_batch_size(const ggml_tensor * op) {
      }
  }
  
@@ -529,7 +529,7 @@ diff --git a/ggml/src/ggml-cuda/ggml-cuda.cu b/ggml/src/ggml-cuda/ggml-cuda.cu
  #ifdef GGML_CUDA_NO_PEER_COPY
      return nullptr;
  #else
-@@ -5500,14 +5523,14 @@ static ggml_backend_event_t ggml_backend_cuda_device_event_new(ggml_backend_dev_
+@@ -5516,14 +5539,14 @@ static ggml_backend_event_t ggml_backend_cuda_device_event_new(ggml_backend_dev_
  #endif
  }
  
@@ -546,7 +546,7 @@ diff --git a/ggml/src/ggml-cuda/ggml-cuda.cu b/ggml/src/ggml-cuda/ggml-cuda.cu
      GGML_UNUSED(dev);
      CUDA_CHECK(cudaEventSynchronize((cudaEvent_t)event->context));
  }
-@@ -5536,23 +5559,23 @@ struct ggml_backend_cuda_reg_context {
+@@ -5552,23 +5575,23 @@ struct ggml_backend_cuda_reg_context {
      std::vector<ggml_backend_dev_t> devices;
  };
  
@@ -574,7 +574,7 @@ diff --git a/ggml/src/ggml-cuda/ggml-cuda.cu b/ggml/src/ggml-cuda/ggml-cuda.cu
      static std::vector<ggml_backend_feature> features = []() {
          std::vector<ggml_backend_feature> features;
      #define _STRINGIFY(...) #__VA_ARGS__
-@@ -5613,7 +5636,7 @@ static ggml_backend_feature * ggml_backend_cuda_get_features(ggml_backend_reg_t
+@@ -5629,7 +5652,7 @@ static ggml_backend_feature * ggml_backend_cuda_get_features(ggml_backend_reg_t
      GGML_UNUSED(reg);
  }
  

--- a/llama.cpp.patches/patches/ggml_src_ggml-vulkan_ggml-vulkan.cpp.patch
+++ b/llama.cpp.patches/patches/ggml_src_ggml-vulkan_ggml-vulkan.cpp.patch
@@ -18,7 +18,7 @@ diff --git a/ggml/src/ggml-vulkan/ggml-vulkan.cpp b/ggml/src/ggml-vulkan/ggml-vu
  static ggml_backend_buffer_type_i ggml_backend_vk_buffer_type_interface = {
      /* .get_name         = */ ggml_backend_vk_buffer_type_name,
      /* .alloc_buffer     = */ ggml_backend_vk_buffer_type_alloc_buffer,
-@@ -2224,7 +2224,7 @@ static void ggml_vk_check_results_1(ggml_backend_vk_context * ctx, ggml_cgraph *
+@@ -2286,7 +2286,7 @@ static void ggml_vk_check_results_1(ggml_backend_vk_context * ctx, ggml_cgraph *
  
  typedef void (*ggml_vk_func_t)(ggml_backend_vk_context * ctx, vk_context& subctx, const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst);
  
@@ -27,7 +27,7 @@ diff --git a/ggml/src/ggml-vulkan/ggml-vulkan.cpp b/ggml/src/ggml-vulkan/ggml-vu
  
  static VkDeviceSize ggml_vk_get_max_buffer_range(const ggml_backend_vk_context * ctx, const vk_buffer &buf, const VkDeviceSize offset) {
      const VkDeviceSize range = std::min(VkDeviceSize{buf->size - offset},
-@@ -14765,20 +14765,28 @@ static bool ggml_backend_buffer_is_vk(ggml_backend_buffer_t buffer) {
+@@ -15055,20 +15055,28 @@ static bool ggml_backend_buffer_is_vk(ggml_backend_buffer_t buffer) {
      return buffer->buft->iface.get_name == ggml_backend_vk_buffer_type_name;
  }
  
@@ -59,7 +59,7 @@ diff --git a/ggml/src/ggml-vulkan/ggml-vulkan.cpp b/ggml/src/ggml-vulkan/ggml-vu
      VK_LOG_DEBUG("ggml_backend_vk_buffer_init_tensor(" << buffer << " (" << buffer->context << "), " << tensor << ")");
      if (tensor->view_src != nullptr) {
          GGML_ASSERT(tensor->view_src->buffer->buft == buffer->buft);
-@@ -14786,7 +14794,7 @@ static enum ggml_status ggml_backend_vk_buffer_init_tensor(ggml_backend_buffer_t
+@@ -15076,7 +15084,7 @@ static enum ggml_status ggml_backend_vk_buffer_init_tensor(ggml_backend_buffer_t
      return GGML_STATUS_SUCCESS;
  }
  
@@ -68,7 +68,7 @@ diff --git a/ggml/src/ggml-vulkan/ggml-vulkan.cpp b/ggml/src/ggml-vulkan/ggml-vu
      VK_LOG_DEBUG("ggml_backend_vk_buffer_memset_tensor(" << buffer << ", " << tensor << ", " << value << ", " << offset << ", " << size << ")");
      ggml_backend_vk_buffer_context * buf_ctx = (ggml_backend_vk_buffer_context *)buffer->context;
      vk_buffer buf = buf_ctx->dev_buffer;
-@@ -14799,7 +14807,7 @@ static void ggml_backend_vk_buffer_memset_tensor(ggml_backend_buffer_t buffer, g
+@@ -15089,7 +15097,7 @@ static void ggml_backend_vk_buffer_memset_tensor(ggml_backend_buffer_t buffer, g
      ggml_vk_buffer_memset(buf, vk_tensor_offset(tensor) + tensor->view_offs + offset, val32, size);
  }
  
@@ -77,7 +77,7 @@ diff --git a/ggml/src/ggml-vulkan/ggml-vulkan.cpp b/ggml/src/ggml-vulkan/ggml-vu
      VK_LOG_DEBUG("ggml_backend_vk_buffer_set_tensor(" << buffer << ", " << tensor << ", " << data << ", " << offset << ", " << size << ")");
      ggml_backend_vk_buffer_context * buf_ctx = (ggml_backend_vk_buffer_context *)buffer->context;
      vk_buffer buf = buf_ctx->dev_buffer;
-@@ -14811,7 +14819,7 @@ static void ggml_backend_vk_buffer_set_tensor(ggml_backend_buffer_t buffer, ggml
+@@ -15101,7 +15109,7 @@ static void ggml_backend_vk_buffer_set_tensor(ggml_backend_buffer_t buffer, ggml
      ggml_vk_buffer_write(buf, vk_tensor_offset(tensor) + tensor->view_offs + offset, data, size);
  }
  
@@ -86,7 +86,7 @@ diff --git a/ggml/src/ggml-vulkan/ggml-vulkan.cpp b/ggml/src/ggml-vulkan/ggml-vu
                                                   size_t size, size_t n_copies, size_t stride_tensor, size_t stride_data) {
      VK_LOG_DEBUG("ggml_backend_vk_buffer_set_tensor_2d(" << buffer << ", " << tensor << ", " << data << ", " << offset << ", " << size << ", " <<
                   n_copies << ", " << stride_tensor << ", " << stride_data << ")");
-@@ -14825,7 +14833,7 @@ static void ggml_backend_vk_buffer_set_tensor_2d(ggml_backend_buffer_t buffer, g
+@@ -15115,7 +15123,7 @@ static void ggml_backend_vk_buffer_set_tensor_2d(ggml_backend_buffer_t buffer, g
      ggml_vk_buffer_write_2d(buf, vk_tensor_offset(tensor) + tensor->view_offs + offset, data, stride_data, stride_tensor, size, n_copies);
  }
  
@@ -95,7 +95,7 @@ diff --git a/ggml/src/ggml-vulkan/ggml-vulkan.cpp b/ggml/src/ggml-vulkan/ggml-vu
      VK_LOG_DEBUG("ggml_backend_vk_buffer_get_tensor(" << buffer << ", " << tensor << ", " << data << ", " << offset << ", " << size << ")");
      ggml_backend_vk_buffer_context * buf_ctx = (ggml_backend_vk_buffer_context *)buffer->context;
  
-@@ -14838,7 +14846,7 @@ static void ggml_backend_vk_buffer_get_tensor(ggml_backend_buffer_t buffer, cons
+@@ -15128,7 +15136,7 @@ static void ggml_backend_vk_buffer_get_tensor(ggml_backend_buffer_t buffer, cons
      ggml_vk_buffer_read(buf, vk_tensor_offset(tensor) + tensor->view_offs + offset, data, size);
  }
  
@@ -104,7 +104,7 @@ diff --git a/ggml/src/ggml-vulkan/ggml-vulkan.cpp b/ggml/src/ggml-vulkan/ggml-vu
                                                   size_t size, size_t n_copies, size_t stride_tensor, size_t stride_data) {
      VK_LOG_DEBUG("ggml_backend_vk_buffer_get_tensor_2d(" << buffer << ", " << tensor << ", " << data << ", " << offset << ", " << size << ", " <<
                   n_copies << ", " << stride_tensor << ", " << stride_data << ")");
-@@ -14853,7 +14861,7 @@ static void ggml_backend_vk_buffer_get_tensor_2d(ggml_backend_buffer_t buffer, c
+@@ -15143,7 +15151,7 @@ static void ggml_backend_vk_buffer_get_tensor_2d(ggml_backend_buffer_t buffer, c
      ggml_vk_buffer_read_2d(buf, vk_tensor_offset(tensor) + tensor->view_offs + offset, data, stride_tensor, stride_data, size, n_copies);
  }
  
@@ -113,7 +113,7 @@ diff --git a/ggml/src/ggml-vulkan/ggml-vulkan.cpp b/ggml/src/ggml-vulkan/ggml-vu
      if (ggml_nbytes(src) == 0) {
          return true;
      }
-@@ -14874,7 +14882,7 @@ static bool ggml_backend_vk_buffer_cpy_tensor(ggml_backend_buffer_t buffer, cons
+@@ -15164,7 +15172,7 @@ static bool ggml_backend_vk_buffer_cpy_tensor(ggml_backend_buffer_t buffer, cons
      UNUSED(buffer);
  }
  
@@ -122,7 +122,7 @@ diff --git a/ggml/src/ggml-vulkan/ggml-vulkan.cpp b/ggml/src/ggml-vulkan/ggml-vu
      ggml_backend_vk_buffer_context * ctx = (ggml_backend_vk_buffer_context *)buffer->context;
  
      ggml_vk_buffer_memset(ctx->dev_buffer, 0, value, buffer->size);
-@@ -14892,16 +14900,17 @@ static ggml_backend_buffer_i ggml_backend_vk_buffer_interface = {
+@@ -15182,16 +15190,17 @@ static ggml_backend_buffer_i ggml_backend_vk_buffer_interface = {
      /* .cpy_tensor      = */ ggml_backend_vk_buffer_cpy_tensor,
      /* .clear           = */ ggml_backend_vk_buffer_clear,
      /* .reset           = */ NULL,
@@ -142,7 +142,7 @@ diff --git a/ggml/src/ggml-vulkan/ggml-vulkan.cpp b/ggml/src/ggml-vulkan/ggml-vu
      VK_LOG_MEMORY("ggml_backend_vk_buffer_type_alloc_buffer(" << size << ")");
      ggml_backend_vk_buffer_type_context * ctx = (ggml_backend_vk_buffer_type_context *) buft->context;
  
-@@ -14917,17 +14926,17 @@ static ggml_backend_buffer_t ggml_backend_vk_buffer_type_alloc_buffer(ggml_backe
+@@ -15207,17 +15216,17 @@ static ggml_backend_buffer_t ggml_backend_vk_buffer_type_alloc_buffer(ggml_backe
      return ggml_backend_buffer_init(buft, ggml_backend_vk_buffer_interface, bufctx, size);
  }
  
@@ -163,7 +163,7 @@ diff --git a/ggml/src/ggml-vulkan/ggml-vulkan.cpp b/ggml/src/ggml-vulkan/ggml-vu
      return ggml_nbytes(tensor);
  
      UNUSED(buft);
-@@ -14945,18 +14954,18 @@ ggml_backend_buffer_type_t ggml_backend_vk_buffer_type(size_t dev_num) {
+@@ -15235,18 +15244,18 @@ ggml_backend_buffer_type_t ggml_backend_vk_buffer_type(size_t dev_num) {
  
  // host buffer type
  
@@ -185,7 +185,7 @@ diff --git a/ggml/src/ggml-vulkan/ggml-vulkan.cpp b/ggml/src/ggml-vulkan/ggml-vu
      VK_LOG_MEMORY("ggml_backend_vk_host_buffer_type_alloc_buffer(" << size << ")");
  
      size += 32;  // Behave like the CPU buffer type
-@@ -14972,19 +14981,20 @@ static ggml_backend_buffer_t ggml_backend_vk_host_buffer_type_alloc_buffer(ggml_
+@@ -15262,19 +15271,20 @@ static ggml_backend_buffer_t ggml_backend_vk_host_buffer_type_alloc_buffer(ggml_
      ggml_backend_buffer_t buffer = ggml_backend_cpu_buffer_from_ptr(ptr, size);
      buffer->buft = buft;
      buffer->iface.free_buffer = ggml_backend_vk_host_buffer_free_buffer;
@@ -208,7 +208,7 @@ diff --git a/ggml/src/ggml-vulkan/ggml-vulkan.cpp b/ggml/src/ggml-vulkan/ggml-vu
      return vk_instance.devices[0]->suballocation_block_size;
  
      UNUSED(buft);
-@@ -15016,13 +15026,13 @@ ggml_backend_buffer_type_t ggml_backend_vk_host_buffer_type() {
+@@ -15306,13 +15316,13 @@ ggml_backend_buffer_type_t ggml_backend_vk_host_buffer_type() {
  
  // backend
  
@@ -224,7 +224,7 @@ diff --git a/ggml/src/ggml-vulkan/ggml-vulkan.cpp b/ggml/src/ggml-vulkan/ggml-vu
      ggml_backend_vk_context * ctx = (ggml_backend_vk_context *)backend->context;
      VK_LOG_DEBUG("ggml_backend_vk_free(" << ctx->name << ")");
  
-@@ -15038,7 +15048,7 @@ static ggml_backend_buffer_type_t ggml_backend_vk_get_default_buffer_type(ggml_b
+@@ -15328,7 +15338,7 @@ static ggml_backend_buffer_type_t ggml_backend_vk_get_default_buffer_type(ggml_b
      return &ctx->device->buffer_type;
  }
  
@@ -233,7 +233,7 @@ diff --git a/ggml/src/ggml-vulkan/ggml-vulkan.cpp b/ggml/src/ggml-vulkan/ggml-vu
                                                  size_t size, size_t n_copies, size_t stride_tensor, size_t stride_data) {
      VK_LOG_DEBUG("ggml_backend_vk_set_tensor_2d_async(" << size << ", " << n_copies << ")");
      ggml_backend_vk_context * ctx = (ggml_backend_vk_context *)backend->context;
-@@ -15102,12 +15112,12 @@ static void ggml_backend_vk_set_tensor_2d_async(ggml_backend_t backend, ggml_ten
+@@ -15392,12 +15402,12 @@ static void ggml_backend_vk_set_tensor_2d_async(ggml_backend_t backend, ggml_ten
      }
  }
  
@@ -248,7 +248,7 @@ diff --git a/ggml/src/ggml-vulkan/ggml-vulkan.cpp b/ggml/src/ggml-vulkan/ggml-vu
                                                  size_t size, size_t n_copies, size_t stride_tensor, size_t stride_data) {
      VK_LOG_DEBUG("ggml_backend_vk_get_tensor_2d_async(" << size << ", " << n_copies << ")");
      ggml_backend_vk_context * ctx = (ggml_backend_vk_context *)backend->context;
-@@ -15158,12 +15168,12 @@ static void ggml_backend_vk_get_tensor_2d_async(ggml_backend_t backend, const gg
+@@ -15448,12 +15458,12 @@ static void ggml_backend_vk_get_tensor_2d_async(ggml_backend_t backend, const gg
      }
  }
  
@@ -263,7 +263,7 @@ diff --git a/ggml/src/ggml-vulkan/ggml-vulkan.cpp b/ggml/src/ggml-vulkan/ggml-vu
      VK_LOG_DEBUG("ggml_backend_vk_cpy_tensor_async(" << src << " -> " << dst << ", size=" << ggml_nbytes(src) << ")");
      ggml_backend_vk_context * ctx = (ggml_backend_vk_context *)backend_dst->context;
  
-@@ -15288,7 +15298,7 @@ static void ggml_vk_synchronize(ggml_backend_vk_context * ctx) {
+@@ -15578,7 +15588,7 @@ static void ggml_vk_synchronize(ggml_backend_vk_context * ctx) {
      }
  }
  
@@ -272,7 +272,7 @@ diff --git a/ggml/src/ggml-vulkan/ggml-vulkan.cpp b/ggml/src/ggml-vulkan/ggml-vu
      VK_LOG_DEBUG("ggml_backend_vk_synchronize()");
      ggml_backend_vk_context * ctx = (ggml_backend_vk_context *)backend->context;
  
-@@ -15824,7 +15834,7 @@ static int32_t find_first_set(uint32_t x) {
+@@ -16114,7 +16124,7 @@ static int32_t find_first_set(uint32_t x) {
      return ret;
  }
  
@@ -281,7 +281,7 @@ diff --git a/ggml/src/ggml-vulkan/ggml-vulkan.cpp b/ggml/src/ggml-vulkan/ggml-vu
      VK_LOG_DEBUG("ggml_backend_vk_graph_compute(" << cgraph->n_nodes << " nodes)");
      ggml_backend_vk_context * ctx = (ggml_backend_vk_context *)backend->context;
  
-@@ -16228,7 +16238,7 @@ static ggml_status ggml_backend_vk_graph_compute(ggml_backend_t backend, ggml_cg
+@@ -16516,7 +16526,7 @@ static ggml_status ggml_backend_vk_graph_compute(ggml_backend_t backend, ggml_cg
  }
  
  // Sort the graph for improved parallelism.
@@ -290,7 +290,7 @@ diff --git a/ggml/src/ggml-vulkan/ggml-vulkan.cpp b/ggml/src/ggml-vulkan/ggml-vu
  {
      VK_LOG_DEBUG("ggml_vk_graph_optimize(" << graph->n_nodes << " nodes)");
      ggml_backend_vk_context * ctx = (ggml_backend_vk_context *)backend->context;
-@@ -16485,7 +16495,7 @@ static void ggml_vk_graph_optimize(ggml_backend_t backend, struct ggml_cgraph *
+@@ -16773,7 +16783,7 @@ static void ggml_vk_graph_optimize(ggml_backend_t backend, struct ggml_cgraph *
      }
  }
  
@@ -299,7 +299,7 @@ diff --git a/ggml/src/ggml-vulkan/ggml-vulkan.cpp b/ggml/src/ggml-vulkan/ggml-vu
      VK_LOG_DEBUG("ggml_backend_vk_event_record(backend=" << backend << ", event=" << event << ")");
      ggml_backend_vk_context * ctx = (ggml_backend_vk_context *)backend->context;
      vk_event *vkev = (vk_event *)event->context;
-@@ -16523,7 +16533,7 @@ static void ggml_backend_vk_event_record(ggml_backend_t backend, ggml_backend_ev
+@@ -16811,7 +16821,7 @@ static void ggml_backend_vk_event_record(ggml_backend_t backend, ggml_backend_ev
      ctx->compute_ctx.reset();
  }
  
@@ -308,7 +308,7 @@ diff --git a/ggml/src/ggml-vulkan/ggml-vulkan.cpp b/ggml/src/ggml-vulkan/ggml-vu
      VK_LOG_DEBUG("ggml_backend_vk_event_wait(backend=" << backend << ", event=" << event << ")");
      ggml_backend_vk_context * ctx = (ggml_backend_vk_context *)backend->context;
      vk_event *vkev = (vk_event *)event->context;
-@@ -16620,7 +16630,10 @@ void ggml_backend_vk_get_device_memory(int device, size_t * free, size_t * total
+@@ -16908,7 +16918,10 @@ void ggml_backend_vk_get_device_memory(int device, size_t * free, size_t * total
              *total += heap.size;
  
              if (membudget_supported && i < budgetprops.heapUsage.size()) {
@@ -320,7 +320,7 @@ diff --git a/ggml/src/ggml-vulkan/ggml-vulkan.cpp b/ggml/src/ggml-vulkan/ggml-vu
              } else {
                  *free += heap.size;
              }
-@@ -16688,38 +16701,38 @@ struct ggml_backend_vk_device_context {
+@@ -16976,38 +16989,38 @@ struct ggml_backend_vk_device_context {
      int op_offload_min_batch_size;
  };
  
@@ -366,7 +366,7 @@ diff --git a/ggml/src/ggml-vulkan/ggml-vulkan.cpp b/ggml/src/ggml-vulkan/ggml-vu
      ggml_backend_vk_device_context * ctx = (ggml_backend_vk_device_context *)dev->context;
  
      props->name        = ggml_backend_vk_device_get_name(dev);
-@@ -16735,13 +16748,13 @@ static void ggml_backend_vk_device_get_props(ggml_backend_dev_t dev, struct ggml
+@@ -17023,13 +17036,13 @@ static void ggml_backend_vk_device_get_props(ggml_backend_dev_t dev, struct ggml
      };
  }
  
@@ -382,7 +382,7 @@ diff --git a/ggml/src/ggml-vulkan/ggml-vulkan.cpp b/ggml/src/ggml-vulkan/ggml-vu
      ggml_backend_vk_device_context * ctx = (ggml_backend_vk_device_context *)dev->context;
      const vk_device& device = ggml_vk_get_device(ctx->device);
  
-@@ -17292,7 +17305,7 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
+@@ -17589,7 +17602,7 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
      UNUSED(dev);
  }
  
@@ -391,7 +391,7 @@ diff --git a/ggml/src/ggml-vulkan/ggml-vulkan.cpp b/ggml/src/ggml-vulkan/ggml-vu
      if (buft->iface.get_name != ggml_backend_vk_buffer_type_name) {
          return false;
      }
-@@ -17318,13 +17331,13 @@ static int64_t ggml_vk_get_op_batch_size(const ggml_tensor * op) {
+@@ -17615,13 +17628,13 @@ static int64_t ggml_vk_get_op_batch_size(const ggml_tensor * op) {
      }
  }
  
@@ -407,7 +407,7 @@ diff --git a/ggml/src/ggml-vulkan/ggml-vulkan.cpp b/ggml/src/ggml-vulkan/ggml-vu
      ggml_backend_vk_device_context * ctx = (ggml_backend_vk_device_context *)dev->context;
      auto device = ggml_vk_get_device(ctx->device);
  
-@@ -17347,7 +17360,7 @@ static ggml_backend_event_t ggml_backend_vk_device_event_new(ggml_backend_dev_t
+@@ -17644,7 +17657,7 @@ static ggml_backend_event_t ggml_backend_vk_device_event_new(ggml_backend_dev_t
      };
  }
  
@@ -416,7 +416,7 @@ diff --git a/ggml/src/ggml-vulkan/ggml-vulkan.cpp b/ggml/src/ggml-vulkan/ggml-vu
      ggml_backend_vk_device_context * ctx = (ggml_backend_vk_device_context *)dev->context;
      auto device = ggml_vk_get_device(ctx->device);
  
-@@ -17367,7 +17380,7 @@ static void ggml_backend_vk_device_event_free(ggml_backend_dev_t dev, ggml_backe
+@@ -17664,7 +17677,7 @@ static void ggml_backend_vk_device_event_free(ggml_backend_dev_t dev, ggml_backe
      delete event;
  }
  
@@ -425,7 +425,7 @@ diff --git a/ggml/src/ggml-vulkan/ggml-vulkan.cpp b/ggml/src/ggml-vulkan/ggml-vu
      VK_LOG_DEBUG("ggml_backend_vk_device_event_synchronize(backend=" << dev << ", event=" << event << ")");
      ggml_backend_vk_device_context * ctx = (ggml_backend_vk_device_context *)dev->context;
      auto device = ggml_vk_get_device(ctx->device);
-@@ -17424,7 +17437,7 @@ static vk_buffer ggml_vk_buffer_from_host_ptr(vk_device & device, void * ptr, si
+@@ -17721,7 +17734,7 @@ static vk_buffer ggml_vk_buffer_from_host_ptr(vk_device & device, void * ptr, si
      return buf;
  }
  
@@ -434,7 +434,7 @@ diff --git a/ggml/src/ggml-vulkan/ggml-vulkan.cpp b/ggml/src/ggml-vulkan/ggml-vu
      VK_LOG_DEBUG("ggml_backend_vk_device_buffer_from_host_ptr(backend=" << dev << ", ptr=" << ptr << ", size=" << size << ")");
      GGML_UNUSED(max_tensor_size);
  
-@@ -17462,17 +17475,17 @@ static const struct ggml_backend_device_i ggml_backend_vk_device_i = {
+@@ -17759,17 +17772,17 @@ static const struct ggml_backend_device_i ggml_backend_vk_device_i = {
      /* .event_synchronize    = */ ggml_backend_vk_device_event_synchronize,
  };
  

--- a/llama.cpp.patches/patches/src_models_dflash.cpp.patch
+++ b/llama.cpp.patches/patches/src_models_dflash.cpp.patch
@@ -1,0 +1,39 @@
+diff --git a/src/models/dflash.cpp b/src/models/dflash.cpp
+--- a/llama.cpp/src/models/dflash.cpp
++++ b/llama.cpp/src/models/dflash.cpp
+@@ -60,17 +60,6 @@ void llama_model_dflash::load_arch_tensors(llama_model_loader &) {
+     }
+ }
+ 
+-std::unique_ptr<llm_graph_context> llama_model_dflash::build_arch_graph(const llm_graph_params & params) const {
+-    switch (params.gtype) {
+-        case LLM_GRAPH_TYPE_ENCODER:
+-            return std::make_unique<graph<true>>(*this, params);
+-        case LLM_GRAPH_TYPE_DEFAULT:
+-        case LLM_GRAPH_TYPE_DECODER:
+-            return std::make_unique<graph<false>>(*this, params);
+-        default:
+-            GGML_ABORT("invalid graph type");
+-    };
+-}
+ 
+ template <>
+ ggml_tensor * llama_model_dflash::graph<true>::build_inp_embd_enc() const {
+@@ -274,3 +263,17 @@ llama_model_dflash::graph<false>::graph(const llama_model & model, const llm_gra
+ 
+     ggml_build_forward_expand(gf, cur);
+ }
++// Defined after the graph<true>/graph<false> constructor specializations above:
++// cosmocc's clang rejects an explicit specialization that appears after the
++// point where make_unique<graph<...>> would implicitly instantiate it.
++std::unique_ptr<llm_graph_context> llama_model_dflash::build_arch_graph(const llm_graph_params & params) const {
++    switch (params.gtype) {
++        case LLM_GRAPH_TYPE_ENCODER:
++            return std::make_unique<graph<true>>(*this, params);
++        case LLM_GRAPH_TYPE_DEFAULT:
++        case LLM_GRAPH_TYPE_DECODER:
++            return std::make_unique<graph<false>>(*this, params);
++        default:
++            GGML_ABORT("invalid graph type");
++    };
++}

--- a/llama.cpp.patches/patches/tools_server_server-http.cpp.patch
+++ b/llama.cpp.patches/patches/tools_server_server-http.cpp.patch
@@ -1,12 +1,12 @@
 diff --git a/tools/server/server-http.cpp b/tools/server/server-http.cpp
 --- a/llama.cpp/tools/server/server-http.cpp
 +++ b/llama.cpp/tools/server/server-http.cpp
-@@ -93,7 +93,7 @@ bool server_http_context::init(const common_params & params) {
+@@ -94,7 +94,7 @@ bool server_http_context::init(const common_params & params) {
  
      auto & srv = pimpl->srv;
  
 -#ifdef CPPHTTPLIB_OPENSSL_SUPPORT
 +#ifdef CPPHTTPLIB_SSL_ENABLED
      if (!params.ssl_file_key.empty() && !params.ssl_file_cert.empty()) {
-         SRV_INF("running with SSL: key = %s, cert = %s\n", params.ssl_file_key.c_str(), params.ssl_file_cert.c_str());
+         SRV_TRC("running with SSL: key = %s, cert = %s\n", params.ssl_file_key.c_str(), params.ssl_file_cert.c_str());
          srv = std::make_unique<httplib::SSLServer>(

--- a/llama.cpp.patches/patches/tools_server_server-models.cpp.patch
+++ b/llama.cpp.patches/patches/tools_server_server-models.cpp.patch
@@ -1,7 +1,7 @@
 diff --git a/tools/server/server-models.cpp b/tools/server/server-models.cpp
 --- a/llama.cpp/tools/server/server-models.cpp
 +++ b/llama.cpp/tools/server/server-models.cpp
-@@ -33,6 +33,7 @@
+@@ -35,6 +35,7 @@
  #include <netinet/in.h>
  #include <arpa/inet.h>
  #include <unistd.h>
@@ -9,7 +9,7 @@ diff --git a/tools/server/server-models.cpp b/tools/server/server-models.cpp
  extern char **environ;
  #endif
  
-@@ -496,13 +497,19 @@ void server_models::load_models() {
+@@ -512,13 +513,19 @@ void server_models::load_models() {
          }
  
          // wait for all targeted models to reach UNLOADED; cv.wait handles unlock/relock
@@ -31,7 +31,7 @@ diff --git a/tools/server/server-models.cpp b/tools/server/server-models.cpp
  
          // collect all threads to join in one pass while the lock is held:
          // - monitoring threads from just-unloaded models (to_unload)
-@@ -807,9 +814,12 @@ void server_models::unload_lru() {
+@@ -823,9 +830,12 @@ void server_models::unload_lru() {
          // wait for unload to complete
          {
              std::unique_lock<std::mutex> lk(mutex);
@@ -47,7 +47,7 @@ diff --git a/tools/server/server-models.cpp b/tools/server/server-models.cpp
          }
      }
  }
-@@ -823,7 +833,10 @@ void server_models::load(const std::string & name) {
+@@ -845,7 +855,10 @@ void server_models::load(const std::string & name, const load_options & opts) {
      std::unique_lock<std::mutex> lk(mutex);
      // edge case: block until any in-progress reload has finished so we always load
      // against the freshest preset and a consistent mapping state
@@ -57,9 +57,9 @@ diff --git a/tools/server/server-models.cpp b/tools/server/server-models.cpp
 +        cv.wait_for(lk, std::chrono::seconds(30));
 +    }
  
-     auto meta = mapping[name].meta;
+     auto meta = opts.custom_meta.has_value() ? *opts.custom_meta : mapping[name].meta;
      if (meta.status != SERVER_MODEL_STATUS_UNLOADED) {
-@@ -915,15 +928,34 @@ void server_models::load(const std::string & name) {
+@@ -947,15 +960,34 @@ void server_models::load(const std::string & name, const load_options & opts) {
          });
  
          std::thread stopping_thread([&]() {
@@ -95,9 +95,9 @@ diff --git a/tools/server/server-models.cpp b/tools/server/server-models.cpp
 +                    this->cv_stop.wait_for(lk, std::chrono::seconds(30));
 +                }
              }
-             // child crashed or finished on its own — skip graceful shutdown sequence
+             // child crashed or finished on its own, skip graceful shutdown sequence
              if (child_proc->stopped.load(std::memory_order_acquire)) {
-@@ -1237,14 +1269,16 @@ void server_models::wait(const std::string & name, std::function<bool(const serv
+@@ -1222,16 +1254,21 @@ void server_models::wait(const std::string & name, std::function<bool(const serv
  }
  
  void server_models::wait(std::unique_lock<std::mutex> & lk, const std::string & name, std::function<bool(const server_model_meta &)> predicate) {
@@ -113,14 +113,19 @@ diff --git a/tools/server/server-models.cpp b/tools/server/server-models.cpp
 +        if (it != mapping.end() && predicate(it->second.meta)) {
 +            break;
          }
--        return false;
+         // model was removed from mapping by another code path (e.g. load_models()).
+         // nothing left to wait for - tell the caller to proceed.
+-        return true;
 -    });
++        if (it == mapping.end()) {
++            break;
++        }
 +        cv.wait_for(lk, std::chrono::seconds(30));
 +    }
  }
  
  bool server_models::ensure_model_ready(const std::string & name) {
-@@ -1894,10 +1928,10 @@ server_http_proxy::server_http_proxy(
+@@ -2158,10 +2195,10 @@ server_http_proxy::server_http_proxy(
      auto pipe = std::make_shared<pipe_t<msg_t>>();
  
      if (scheme == "https") {

--- a/llama.cpp.patches/patches/tools_server_server.cpp.patch
+++ b/llama.cpp.patches/patches/tools_server_server.cpp.patch
@@ -1,7 +1,7 @@
 diff --git a/tools/server/server.cpp b/tools/server/server.cpp
 --- a/llama.cpp/tools/server/server.cpp
 +++ b/llama.cpp/tools/server/server.cpp
-@@ -14,6 +14,7 @@
+@@ -15,6 +15,7 @@
  #include <atomic>
  #include <clocale>
  #include <exception>
@@ -9,7 +9,7 @@ diff --git a/tools/server/server.cpp b/tools/server/server.cpp
  #include <signal.h>
  #include <thread> // for std::thread::hardware_concurrency
  
-@@ -21,6 +22,11 @@
+@@ -22,6 +23,11 @@
  #include <windows.h>
  #endif
  
@@ -21,7 +21,7 @@ diff --git a/tools/server/server.cpp b/tools/server/server.cpp
  static std::function<void(int)> shutdown_handler;
  static std::atomic_flag is_terminating = ATOMIC_FLAG_INIT;
  
-@@ -71,15 +77,26 @@ static server_http_context::handler_t ex_wrapper(server_http_context::handler_t
+@@ -72,15 +78,26 @@ static server_http_context::handler_t ex_wrapper(server_http_context::handler_t
      };
  }
  
@@ -51,8 +51,8 @@ diff --git a/tools/server/server.cpp b/tools/server/server.cpp
 +
      common_init();
  
-     if (!common_params_parse(argc, argv, params, LLAMA_EXAMPLE_SERVER)) {
-@@ -332,6 +349,13 @@ int llama_server(int argc, char ** argv) {
+     // start the stream session manager GC right after common init, before any HTTP route can
+@@ -409,6 +426,13 @@ int llama_server(int argc, char ** argv) {
              // this will unblock start_loop()
              ctx_server.terminate();
          };
@@ -66,19 +66,19 @@ diff --git a/tools/server/server.cpp b/tools/server/server.cpp
      }
  
      // TODO: refactor in common/console
-@@ -368,6 +392,11 @@ int llama_server(int argc, char ** argv) {
-     } else {
-         SRV_INF("server is listening on %s\n", ctx_http.listening_address.c_str());
+@@ -428,6 +452,11 @@ int llama_server(int argc, char ** argv) {
  
-+        // Notify caller that server is ready (for combined mode TUI startup)
-+        if (on_ready) {
-+            on_ready(ctx_http.listening_address);
-+        }
+     SRV_INF("listening on %s\n", ctx_http.listening_address.c_str());
+ 
++    // Notify caller that server is ready (for combined mode TUI startup)
++    if (on_ready) {
++        on_ready(ctx_http.listening_address);
++    }
 +
-         // optionally, notify router server that this instance is ready
-         std::thread monitor_thread;
-         if (child.is_child()) {
-@@ -392,5 +421,48 @@ int llama_server(int argc, char ** argv) {
+     if (is_router_server) {
+         SRV_WRN("%s", "NOTE: router mode is experimental\n");
+         SRV_WRN("%s", "      it is not recommended to use this mode in untrusted environments\n");
+@@ -468,5 +497,48 @@ int llama_server(int argc, char ** argv) {
          }
      }
  

--- a/llamafile/BUILD.mk
+++ b/llamafile/BUILD.mk
@@ -249,6 +249,7 @@ LLAMAFILE_SERVER_SUPPORT_OBJS := \
 	o/$(MODE)/llama.cpp/tools/server/server-models.cpp.o \
 	o/$(MODE)/llama.cpp/tools/server/server-queue.cpp.o \
 	o/$(MODE)/llama.cpp/tools/server/server-schema.cpp.o \
+	o/$(MODE)/llama.cpp/tools/server/server-stream.cpp.o \
 	o/$(MODE)/llama.cpp/tools/server/server-task.cpp.o \
 	o/$(MODE)/llama.cpp/tools/server/server-tools.cpp.o \
 	$(UI_GEN_OBJ)

--- a/tests/integration/tests/test_tool_calling.py
+++ b/tests/integration/tests/test_tool_calling.py
@@ -8,6 +8,10 @@ from utils.llamafile import LlamafileRunner
 
 
 # Example tool definition for testing
+# MiniCPM5 and other Jinja-templated models need --jinja for tool-call parsing.
+TOOL_CALLING_SERVER_ARGS = ["--jinja", "-ngl", "0"]
+
+
 CALCULATOR_TOOL = {
     "type": "function",
     "function": {
@@ -52,7 +56,9 @@ class TestToolCalling:
 
     def test_tool_call_basic(self, llamafile, server_port, timeouts):
         """Test that model can make a tool call."""
-        proc = llamafile.start_server(port=server_port)
+        proc = llamafile.start_server(
+            port=server_port, extra_args=TOOL_CALLING_SERVER_ARGS
+        )
 
         try:
             ready = LlamafileRunner.wait_for_server(
@@ -87,7 +93,9 @@ class TestToolCalling:
 
     def test_tool_call_correct_function(self, llamafile, server_port, timeouts):
         """Test that model calls the correct tool."""
-        proc = llamafile.start_server(port=server_port)
+        proc = llamafile.start_server(
+            port=server_port, extra_args=TOOL_CALLING_SERVER_ARGS
+        )
 
         try:
             ready = LlamafileRunner.wait_for_server(
@@ -118,7 +126,9 @@ class TestToolCalling:
 
     def test_tool_call_with_arguments(self, llamafile, server_port, timeouts):
         """Test that tool calls include correct arguments."""
-        proc = llamafile.start_server(port=server_port)
+        proc = llamafile.start_server(
+            port=server_port, extra_args=TOOL_CALLING_SERVER_ARGS
+        )
 
         try:
             ready = LlamafileRunner.wait_for_server(


### PR DESCRIPTION
## Description

Bumps the `llama.cpp` submodule to `c818263f2`, which adds upstream MiniCPM5 chat/tool-call parsing ([ggerganov/llama.cpp#24889](https://github.com/ggerganov/llama.cpp/pull/24889)). Regenerates the full `llama.cpp.patches/` set so the cosmocc build still applies cleanly, and wires new upstream sources into the llamafile build.

**Branch:** `llamacpp_c818263f2` (per CONTRIBUTING.md / bump workflow — not committed directly to `main`)

**Submodule**
- `llama.cpp` → `c818263f2` (`chat: implement minicpm5 parser`)

**Patch / build reconciliation**
- Regenerated all 39 patches via `generate-patches` after proving a clean build + `make check`
- `llamafile-files/BUILD.mk`: drop removed `json-partial.cpp`; add `dflash.cpp` and `server-stream.cpp`
- `llamafile/BUILD.mk`: link `server-stream.cpp.o` in `LLAMAFILE_SERVER_SUPPORT_OBJS`
- New `src_models_dflash.cpp.patch`: cosmocc/clang fix — move `build_arch_graph()` after `graph<true>`/`graph<false>` template specializations (same pattern as the existing `eagle3` patch)
- Refreshed drifted hunks in backend/server patches (CUDA, Vulkan, CPU ops, server models, etc.)

**Tests**
- Tool-calling integration tests pass `--jinja -ngl 0` so Jinja-templated models (including MiniCPM5) parse tool calls correctly

**Verification performed locally**
- `make setup` — all patches apply cleanly
- Clean build of `o/llamafile/llamafile`
- `make check` — unit tests green
- `llamafile:verify-clean` round-trip (reset → setup → clean build → check)
- Integration: `tests/test_tool_calling.py` (3/3) against built binary and rebundled `.llamafile` with MiniCPM5-1B Q8_0

**Host handoff (not run in-session — per bump doc)**
- [ ] CUDA / ROCm smoke test
- [ ] Windows smoke test
- [ ] macOS Metal runtime compile + run
- [ ] Web UI curl check (`GET /`, `/_app/immutable/...`)
- [ ] Long-run stability

## PR Type

- 🆕 New Feature
- 🚦 Infrastructure

## Relevant issues

- Enables MiniCPM5 tool calling via upstream [ggerganov/llama.cpp#24889](https://github.com/ggerganov/llama.cpp/pull/24889)
- Searched mozilla-ai/llamafile issues and open PRs — no duplicate; this bump is novel
- No pre-discussion issue filed: confined routine `llama.cpp` submodule patch bump (not a new user-facing feature or architectural change per CONTRIBUTING.md §Discuss major changes)

## Checklist

- [x] I understand the code I am submitting.
- [x] I have run this code locally and verified the change.
- [x] New and existing tests pass locally, or I have explained why tests were not run.
- [x] Documentation was updated where necessary.
- [x] If I changed code in `llama.cpp/`, `whisper.cpp/`, or `stable-diffusion.cpp/`, I also updated the matching `*.patches/` files.
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/llamafile/blob/main/CONTRIBUTING.md).
- [ ] **AI Usage:**
    - [ ] No AI was used.
    - [ ] AI was used in an assistive capacity.
    - [x] This PR includes substantial AI-generated content.

## AI Usage Information

- **AI Model used:** Grok (xAI, Research, Code), MiniCPM5 (Action Classifier)
- **AI Developer Tool used:** opencode an autonomous VM sandbox
- **Any other info you'd like to share:** AI assisted with the canonical llama.cpp bump workflow (`check_patches.sh` → reconcile → `generate-patches` → `verify-clean`), patch regeneration, BUILD.mk reconciliation for upstream file moves, the cosmocc `dflash.cpp` compile-order fix, integration-test updates (`--jinja`), and local verification (build, unit tests, MiniCPM5 tool-calling integration tests). All changes were reviewed against llamafile's patch workflow docs and CONTRIBUTING.md; submodule edits were made only in-place for patch generation, with `llama.cpp.patches/` as the committed source of truth.

When answering reviewer questions, please respond yourself rather than pasting reviewer comments into an AI system and posting the reply back unchanged.

- [ ] I am an AI Agent filling out this form (check box if true)