### PR TITLE
docs(quickstart): clarify llamafile vs llamafile-thin and other release binaries (#1022)

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -209,7 +209,8 @@ libraries are appended to it:
   or `llamafile/rocm.sh` (AMD), which needs a local GPU toolchain (`nvcc` /
   `hipcc`) at build time.
 - **`llamafile`** is that same binary with `ggml-cuda` and `ggml-vulkan`
-  appended, for both Linux (`.so`) and Windows (`.dll`). Those backends work
+  appended, as **`x86_64`** Linux (`.so`) and Windows (`.dll`) artifacts (a
+  single set of libraries, with no separate ARM build). Those backends work
   with no build step of your own — you only need a driver that provides the
   corresponding runtime API. The bundled libraries are what makes this file
   larger.
@@ -218,9 +219,11 @@ Note that ROCm is not bundled in either file. AMD users who do not want to use
 the Vulkan backend have to build `ggml-rocm` with `llamafile/rocm.sh` either
 way.
 
-The bundled libraries are also Linux and Windows artifacts only. On macOS
-neither file carries a pre-built backend, so the two downloads behave the same
-there and GPU support comes from the usual runtime path instead.
+The bundled libraries are `x86_64` Linux and Windows artifacts only. On any
+other platform (macOS, or a non-`x86_64` architecture such as an `aarch64`/ARM64
+Linux host, even one with an NVIDIA GPU) neither file carries an applicable
+pre-built backend, so the two downloads behave the same there and GPU support
+comes from the usual runtime path instead.
 
 Use `llamafile` unless you want the smallest download, only need CPU inference,
 or have already set up your own GPU backend libraries.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -182,6 +182,39 @@ curl -L -o gpt-oss.gguf https://huggingface.co/unsloth/gpt-oss-20b-GGUF/resolve/
 
 Windows users may need to change `./llamafile.exe` to `.\llamafile.exe` when running the above command.
 
+### Which release file do I download?
+
+On the [releases page](https://github.com/mozilla-ai/llamafile/releases) each
+release ships several *independent* single-file programs. They are **not**
+bundled together inside `llamafile`; pick the one that matches the task you
+want to perform:
+
+| File | What it is |
+| --- | --- |
+| `llamafile` | Runs LLMs (chat/completions). This is the program referenced throughout these docs. |
+| `llamafile-thin` | The same `llamafile` program, but **without the pre-built GPU libraries bundled in** (see below). |
+| `whisperfile` | Speech-to-text, built on [whisper.cpp](https://github.com/ggml-org/whisper.cpp). See the [whisperfile docs](whisperfile/index.md). |
+| `transcribefile` | Speech-to-text, built on [transcribe.cpp](https://github.com/handy-computer/transcribe.cpp). |
+| `diffusionfile` | Image generation (Stable Diffusion). |
+| `zipalign` | A small utility for embedding weights or other assets into a llamafile. |
+
+#### `llamafile` vs `llamafile-thin`
+
+Both are the *same* executable — the only difference is whether the pre-built
+GPU support libraries are packaged inside:
+
+- **`llamafile`** has the pre-built CUDA and Vulkan libraries (for both Linux
+  `.so` and Windows `.dll`) appended into the file, so GPU acceleration works
+  out of the box without a local GPU toolchain. This makes the download larger.
+- **`llamafile-thin`** is a copy of the binary taken *before* those GPU
+  libraries were added, so it is a much smaller download. It still runs on the
+  CPU, and can still use your GPU when the matching GPU support libraries are
+  available on your system.
+
+As a rule of thumb: use **`llamafile`** if you want GPU acceleration to just
+work; use **`llamafile-thin`** if you want the smallest download, only need CPU
+inference, or already have your GPU libraries set up.
+
 
 ## Running llamafile with models downloaded by third-party applications
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -192,7 +192,7 @@ want to perform:
 | File | What it is |
 | --- | --- |
 | `llamafile` | Runs LLMs (chat/completions). This is the program referenced throughout these docs. |
-| `llamafile-thin` | The same `llamafile` program, but **without the pre-built GPU libraries bundled in** (see below). |
+| `llamafile-thin` | The same program, without the pre-built GPU libraries appended (see below). |
 | `whisperfile` | Speech-to-text, built on [whisper.cpp](https://github.com/ggml-org/whisper.cpp). See the [whisperfile docs](whisperfile/index.md). |
 | `transcribefile` | Speech-to-text, built on [transcribe.cpp](https://github.com/handy-computer/transcribe.cpp). |
 | `diffusionfile` | Image generation (Stable Diffusion). |
@@ -200,20 +200,26 @@ want to perform:
 
 #### `llamafile` vs `llamafile-thin`
 
-Both are the *same* executable — the only difference is whether the pre-built
-GPU support libraries are packaged inside:
+Both are the same executable. The difference is whether pre-built GPU backend
+libraries are appended to it:
 
-- **`llamafile`** has the pre-built CUDA and Vulkan libraries (for both Linux
-  `.so` and Windows `.dll`) appended into the file, so GPU acceleration works
-  out of the box without a local GPU toolchain. This makes the download larger.
-- **`llamafile-thin`** is a copy of the binary taken *before* those GPU
-  libraries were added, so it is a much smaller download. It still runs on the
-  CPU, and can still use your GPU when the matching GPU support libraries are
-  available on your system.
+- **`llamafile-thin`** is the base binary, so it is the smaller download. It
+  runs on the CPU, and uses a GPU only if a matching backend library is already
+  on your system. You produce those yourself with `llamafile/cuda.sh` (NVIDIA)
+  or `llamafile/rocm.sh` (AMD), which needs a local GPU toolchain (`nvcc` /
+  `hipcc`) at build time.
+- **`llamafile`** is that same binary with `ggml-cuda` and `ggml-vulkan`
+  appended, for both Linux (`.so`) and Windows (`.dll`). Those backends work
+  with no build step of your own — you only need a driver that provides the
+  corresponding runtime API. The bundled libraries are what makes this file
+  larger.
 
-As a rule of thumb: use **`llamafile`** if you want GPU acceleration to just
-work; use **`llamafile-thin`** if you want the smallest download, only need CPU
-inference, or already have your GPU libraries set up.
+Note that ROCm is not bundled in either file. AMD users who do not want to use
+the Vulkan backend have to build `ggml-rocm` with `llamafile/rocm.sh` either
+way.
+
+Use `llamafile` unless you want the smallest download, only need CPU inference,
+or have already set up your own GPU backend libraries.
 
 
 ## Running llamafile with models downloaded by third-party applications

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -218,6 +218,10 @@ Note that ROCm is not bundled in either file. AMD users who do not want to use
 the Vulkan backend have to build `ggml-rocm` with `llamafile/rocm.sh` either
 way.
 
+The bundled libraries are also Linux and Windows artifacts only. On macOS
+neither file carries a pre-built backend, so the two downloads behave the same
+there and GPU support comes from the usual runtime path instead.
+
 Use `llamafile` unless you want the smallest download, only need CPU inference,
 or have already set up your own GPU backend libraries.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -186,7 +186,8 @@ Windows users may need to change `./llamafile.exe` to `.\llamafile.exe` when run
 
 On the [releases page](https://github.com/mozilla-ai/llamafile/releases) each
 release ships several *independent* single-file programs. They are **not**
-bundled together inside `llamafile`; pick the one that matches the task you
+bundled together inside the `llamafile` executable: if you want to download all of them
+at once, choose the zip download; otherwise, pick the one that matches the task you
 want to perform:
 
 | File | What it is |
@@ -200,24 +201,29 @@ want to perform:
 
 #### `llamafile` vs `llamafile-thin`
 
-Both are the same executable. The difference is whether pre-built GPU backend
-libraries are appended to it:
+Both files contain the same executable code. The difference is whether pre-built GPU backend
+libraries are bundled together with it:
 
 - **`llamafile-thin`** is the base binary, so it is the smaller download. It
-  runs on the CPU, and uses a GPU only if a matching backend library is already
-  on your system. You produce those yourself with `llamafile/cuda.sh` (NVIDIA)
-  or `llamafile/rocm.sh` (AMD), which needs a local GPU toolchain (`nvcc` /
-  `hipcc`) at build time.
+  seamlessly runs on different operating systems and CPU architectures. To run on GPU,
+  it requires a matching backend library to be available on your system. On Apple Silicon this
+  is fully transparent: if the system does not have the required library, llamafile compiles
+  one on the fly. On the other systems, you can build GPU libraries yourself with `llamafile/cuda.sh`
+  (NVIDIA), `llamafile/rocm.sh` (AMD), or `llamafile/vulkan.sh` (NVIDIA + AMD + others). 
+  Each library requires the respective GPU toolchain to be installed before you run a build.
+  As an alternative, you can find libraries for the latest release on our
+  [HuggingFace repo](https://huggingface.co/mozilla-ai/llamafile_0.10).
 - **`llamafile`** is that same binary with `ggml-cuda` and `ggml-vulkan`
-  appended, as **`x86_64`** Linux (`.so`) and Windows (`.dll`) artifacts (a
+  bundled, as **`x86_64`** Linux (`.so`) and Windows (`.dll`) artifacts (a
   single set of libraries, with no separate ARM build). Those backends work
   with no build step of your own — you only need a driver that provides the
   corresponding runtime API. The bundled libraries are what makes this file
   larger.
 
-Note that ROCm is not bundled in either file. AMD users who do not want to use
-the Vulkan backend have to build `ggml-rocm` with `llamafile/rocm.sh` either
-way.
+Note that ROCm support is still experimental and thus not automatically bundled in either file.
+AMD users who do not want to use the Vulkan backend have to build `ggml-rocm` with 
+`llamafile/rocm.sh`, or download the pre-built `ggml-rocm` dylibs from llamafile's HuggingFace
+repo, regardless of which llamafile executable they are running.
 
 The bundled libraries are `x86_64` Linux and Windows artifacts only. On any
 other platform (macOS, or a non-`x86_64` architecture such as an `aarch64`/ARM64
@@ -225,8 +231,8 @@ Linux host, even one with an NVIDIA GPU) neither file carries an applicable
 pre-built backend, so the two downloads behave the same there and GPU support
 comes from the usual runtime path instead.
 
-Use `llamafile` unless you want the smallest download, only need CPU inference,
-or have already set up your own GPU backend libraries.
+Use `llamafile` unless you want the smallest download and only need CPU inference,
+you have an Apple Silicon Mac, or have already set up your own GPU backend libraries.
 
 
 ## Running llamafile with models downloaded by third-party applications


### PR DESCRIPTION
## What

Adds a **"Which release file do I download?"** subsection to the Quickstart's
*Using llamafile with external weights* section, clarifying:

1. What each binary on the releases page is (`llamafile`, `llamafile-thin`, `whisperfile`, `transcribefile`, `diffusionfile`, `zipalign`) and that they are **independent** single-file programs — the larger `llamafile` does **not** bundle the others together.
2. The concrete difference between `llamafile` and `llamafile-thin`.

## Why

Fixes #1022. A user asked what distinguishes `llamafile` from the newer `llamafile-thin`, and whether the full `llamafile` just packages `transcribe`, `whisper`, etc. together — none of which is documented.

## Source of truth

The distinction is defined in [`llamafile/release.sh`](https://github.com/mozilla-ai/llamafile/blob/main/llamafile/release.sh): `llamafile-thin` is copied from `llamafile` *before* the pre-built GPU libraries (`ggml-cuda.so/.dll`, `ggml-vulkan.so/.dll`) are `zipalign`-appended into `llamafile`, and `whisperfile`/`transcribefile`/`diffusionfile`/`zipalign` are copied as separate binaries. The wording in this PR is kept conservative to match exactly what that script does.

Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
