### PR TITLE
docs: clarify llamafile vs llamafile-thin release binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,19 @@ responses.
 
 **Note - Only executables under 4GB can run on Windows, so any llamafile above 4GB won't work. Download the [llamafile](https://github.com/mozilla-ai/llamafile/releases) binary and run it with any [external weights/models(GGUF)](https://docs.mozilla.ai/llamafile/getting-started/quickstart#using-llamafile-with-external-weights).**
 
+### `llamafile` vs `llamafile-thin` (release binaries)
+
+GitHub releases ship both `llamafile-<version>` and `llamafile-<version>-thin`. They are the **same engine binary**; the difference is packaging:
+
+| Artifact | What it contains | Typical size | When to use |
+|---|---|---|---|
+| **`llamafile`** | Engine **plus** prebuilt GPU backend libraries embedded with `zipalign` (`ggml-cuda` / `ggml-vulkan` `.so`/`.dll`) | Larger (hundreds of MB) | One-file download with GPU acceleration libs already inside |
+| **`llamafile-thin`** | Engine **only** (no GPU libs zip-appended) | Smaller (~tens of MB) | CPU-only, or you already provide GPU backends yourself |
+
+Other release tools (`whisperfile`, `diffusionfile`, `transcribefile`, `zipalign`) are separate single-purpose binaries — they are **not** bundled inside `llamafile` / `llamafile-thin`. The full `llamafile` binary is the LLM runner (plus optional embedded GPU DSOs), not a mega-binary of every tool.
+
+See `llamafile/release.sh` for how the thin copy is taken before GPU libs are zipalign'd into the full binary.
+
 ## Documentation
 
 Check the full documentation at [docs.mozilla.ai/llamafile](https://docs.mozilla.ai/llamafile), or directly jump into one of the following subsections:

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,15 @@ Whether you are a new user or a long-time fan, please share what you find most v
 [Read more via the blog](https://blog.mozilla.ai/llamafile-returns/) and add your voice to the discussion [here](https://github.com/mozilla-ai/llamafile/discussions/809).
 
 
+## `llamafile` vs `llamafile-thin`
+
+Release builds publish both `llamafile-<version>` and `llamafile-<version>-thin`.
+
+- **`llamafile`**: the engine with GPU backend libraries (`ggml-cuda` / `ggml-vulkan` for Linux/Windows) embedded via `zipalign` so GPU acceleration can work from a single download.
+- **`llamafile-thin`**: the **same engine** without those GPU libraries appended — smaller download for CPU-only use or custom GPU setups.
+
+`whisperfile`, `diffusionfile`, and `transcribefile` remain separate release artifacts; they are not packed inside the main `llamafile` binary.
+
 ## How llamafile works
 
 A llamafile is an executable LLM that you can run on your own


### PR DESCRIPTION
## Summary

Documents the difference between release artifacts `llamafile` and `llamafile-thin`:

- **thin** = engine only (no GPU backend libs appended)
- **full** = same engine + zipalign'd `ggml-cuda` / `ggml-vulkan` libraries
- `whisperfile` / `diffusionfile` / `transcribefile` remain separate binaries

Based on `llamafile/release.sh` packaging flow.

Fixes #1022

## Testing

Docs-only.
