### PR TITLE
fix(server): diagnose AF_UNIX bind failures and unlink stale sockets

### DIFF
--- a/llama.cpp.patches/patches/tools_server_server-http.cpp.patch
+++ b/llama.cpp.patches/patches/tools_server_server-http.cpp.patch
@@ -1,7 +1,19 @@
-diff --git a/tools/server/server-http.cpp b/tools/server/server-http.cpp
 --- a/llama.cpp/tools/server/server-http.cpp
 +++ b/llama.cpp/tools/server/server-http.cpp
-@@ -104,7 +104,7 @@ bool server_http_context::init(const common_params & params) {
+@@ -11,6 +11,12 @@
+ #include <memory>
+ #include <string>
+ #include <thread>
++#include <cerrno>
++#include <cstring>
++#include <sys/stat.h>
++#ifndef _WIN32
++#include <unistd.h>
++#endif
+ 
+ //
+ // HTTP implementation using cpp-httplib
+@@ -104,7 +110,7 @@
  
      auto & srv = pimpl->srv;
  
@@ -10,3 +22,44 @@ diff --git a/tools/server/server-http.cpp b/tools/server/server-http.cpp
      if (!params.ssl_file_key.empty() && !params.ssl_file_cert.empty()) {
          SRV_TRC("running with SSL: key = %s, cert = %s\n", params.ssl_file_key.c_str(), params.ssl_file_cert.c_str());
          srv = std::make_unique<httplib::SSLServer>(
+@@ -434,6 +440,27 @@
+         is_sock = true;
+         SRV_TRC("%s", "setting address family to AF_UNIX\n");
+         srv->set_address_family(AF_UNIX);
++        // Stale filesystem sockets make bind(2) fail with EADDRINUSE. Remove any
++        // pre-existing path first so --host /path.sock is restartable. If the
++        // path exists but is not a socket, leave it alone and let bind fail with
++        // a clear errno (issue #971).
++#ifndef _WIN32
++        {
++            struct stat st;
++            if (::stat(hostname.c_str(), &st) == 0) {
++                if (S_ISSOCK(st.st_mode)) {
++                    if (::unlink(hostname.c_str()) != 0) {
++                        SRV_ERR("couldn't remove existing HTTP server socket '%s': %s (errno=%d)\n",
++                                hostname.c_str(), strerror(errno), errno);
++                    } else {
++                        SRV_TRC("removed existing HTTP server socket path: %s\n", hostname.c_str());
++                    }
++                } else {
++                    SRV_ERR("HTTP server socket path exists and is not a socket: %s\n", hostname.c_str());
++                }
++            }
++        }
++#endif
+         // bind_to_port requires a second arg, any value other than 0 should
+         // simply get ignored
+         was_bound = srv->bind_to_port(hostname, 8080);
+@@ -452,7 +479,11 @@
+     }
+ 
+     if (!was_bound) {
+-        SRV_ERR("couldn't bind HTTP server socket, hostname: %s, port: %d\n", hostname.c_str(), port);
++        // Surface errno so AF_UNIX failures are diagnosable (path length,
++        // permissions, EADDRINUSE, etc.). errno is from the last failed bind
++        // or listen inside cpp-httplib.
++        SRV_ERR("couldn't bind HTTP server socket, hostname: %s, port: %d: %s (errno=%d)\n",
++                hostname.c_str(), port, strerror(errno), errno);
+         return false;
+     }
+ 

--- a/tests/integration/tests/test_server.py
+++ b/tests/integration/tests/test_server.py
@@ -1,5 +1,7 @@
 """Server mode integration tests."""
 
+import socket
+
 import pytest
 
 from utils.llamafile import LlamafileRunner
@@ -22,6 +24,26 @@ class TestServerBasic:
         finally:
             proc.terminate()
             proc.wait()
+
+    @pytest.mark.skipif(
+        not hasattr(socket, "AF_UNIX"), reason="AF_UNIX is not available on this platform"
+    )
+    def test_server_replaces_stale_unix_socket(self, llamafile, tmp_path, timeouts):
+        """Test that a stale Unix socket is replaced and accepts HTTP traffic."""
+        socket_path = tmp_path / "llamafile.sock"
+        stale_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        stale_socket.bind(str(socket_path))
+        stale_socket.close()
+
+        proc = llamafile.start_server(extra_args=["--host", str(socket_path)])
+        try:
+            assert LlamafileRunner.wait_for_unix_server(
+                str(socket_path), proc=proc, timeout=timeouts.server_ready
+            ), "Server did not replace the stale Unix socket and become ready"
+        finally:
+            proc.terminate()
+            proc.wait()
+            socket_path.unlink(missing_ok=True)
 
     def test_server_chat_completion(self, llamafile, server_port, timeouts):
         """Test basic chat completion endpoint."""

--- a/tests/integration/utils/llamafile.py
+++ b/tests/integration/utils/llamafile.py
@@ -6,6 +6,7 @@ import logging
 import os
 import platform
 import select
+import socket
 import subprocess
 import time
 from pathlib import Path
@@ -471,6 +472,39 @@ class LlamafileRunner:
             time.sleep(poll_interval)
 
         logger.warning("Server not ready after %.1fs", timeout)
+        return False
+
+    @staticmethod
+    def wait_for_unix_server(
+        socket_path: str,
+        proc: subprocess.Popen,
+        timeout: float = TIMEOUT_SERVER_READY,
+        poll_interval: float = POLL_INTERVAL,
+    ) -> bool:
+        """Wait for an HTTP health response over an AF_UNIX socket."""
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            if proc.poll() is not None:
+                logger.warning(
+                    "Server process exited before its Unix socket became ready (rc=%s)",
+                    proc.returncode,
+                )
+                return False
+            try:
+                with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+                    client.settimeout(2)
+                    client.connect(socket_path)
+                    client.sendall(
+                        b"GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+                    )
+                    status_line = client.recv(256).split(b"\r\n", 1)[0]
+                    if b" 200 " in status_line:
+                        return True
+            except (OSError, TimeoutError):
+                pass
+            time.sleep(poll_interval)
+
+        logger.warning("Unix socket server not ready after %.1fs", timeout)
         return False
 
     @staticmethod


### PR DESCRIPTION
## Summary
- `llamafile --server --host /path.sock` can fail at `bind(2)` with only a generic log line and no errno, making AF_UNIX failures undiagnosable.
- A leftover filesystem socket from a previous run commonly causes `EADDRINUSE`.
- Unlink an existing socket path before bind (non-Windows).
- Include `strerror(errno)` in the bind failure log.

Fixes #971

## Test plan
- [ ] Build with `make setup && make -j$(nproc)` (or project default)
- [ ] `./llamafile --server --host /tmp/test.sock --model <any.gguf>` should bind; restart should succeed after unlink
- [ ] If bind fails for permissions/path length, log should include errno/strerror
