### PR TITLE
docs(support): document the Vulkan GPU backend (#1029)

### DIFF
--- a/docs/support.md
+++ b/docs/support.md
@@ -41,11 +41,11 @@ There is no Intel oneAPI/SYCL backend, but Vulkan covers a lot of the
 hardware that CUDA and ROCm do not. On hardware outside the table below,
 llamafile runs on the CPU.
 
-Vulkan is loaded the same way as CUDA and ROCm: llamafile looks for a
-prebuilt `ggml-vulkan.so` / `ggml-vulkan.dll` (the full `llamafile` release
-bundles both) and otherwise falls back to a library you build yourself with
-`llamafile/vulkan.sh` (`vulkan.bat` on Windows) — see
-[Building the GPU libraries](building_dlls.md). On macOS, Vulkan runs
+Vulkan is loaded exactly like the CUDA and ROCm backends: llamafile looks
+for a prebuilt `ggml-vulkan.so` / `ggml-vulkan.dll`, first inside the
+bundle and then in `~/.llamafile/` — see
+[Building the GPU libraries](building_dlls.md) for where that library comes
+from on each platform. On macOS, Vulkan runs
 through MoltenVK; Apple Silicon users normally want the built-in Metal
 backend instead. If the Vulkan library loads but reports no usable device,
 llamafile skips it and continues with the next backend rather than failing.
@@ -56,7 +56,6 @@ llamafile skips it and continues with the next backend rather than failing.
 | NVIDIA | CUDA / cuBLAS | Linux, Windows, WSL | Supported | Pass `-ngl 999` to offload; Windows release binaries ship prebuilt DLLs |
 | AMD | HIP / rocBLAS | Linux, Windows | Supported | Pass `-ngl 999` to offload; multi-GPU may be broken on Radeon (see below) |
 | Any (incl. Intel) | Vulkan | Linux, Windows, macOS | Supported | Pass `-ngl 999` to offload; select with `--gpu vulkan`. Used in `--gpu auto` when no vendor backend is available |
-| Intel / other | oneAPI / SYCL | — | Not supported | No SYCL backend; use the Vulkan row above, or build llama.cpp directly |
 
 The 0.10.* series has not been tested on every GPU and platform yet, so
 treat the AMD and Windows paths in particular as best-effort.

--- a/docs/support.md
+++ b/docs/support.md
@@ -36,16 +36,27 @@ llamafile supports the following CPUs:
 
 ## GPU support
 
-llamafile ships GPU acceleration for Apple Metal, NVIDIA, and AMD. There is
-no Vulkan or Intel oneAPI/SYCL backend, so on hardware outside the table
-below llamafile runs on the CPU.
+llamafile ships GPU acceleration for Apple Metal, NVIDIA, AMD, and Vulkan.
+There is no Intel oneAPI/SYCL backend, but Vulkan covers a lot of the
+hardware that CUDA and ROCm do not. On hardware outside the table below,
+llamafile runs on the CPU.
+
+Vulkan is loaded the same way as CUDA and ROCm: llamafile looks for a
+prebuilt `ggml-vulkan.so` / `ggml-vulkan.dll` (the full `llamafile` release
+bundles both) and otherwise falls back to a library you build yourself with
+`llamafile/vulkan.sh` (`vulkan.bat` on Windows) — see
+[Building the GPU libraries](building_dlls.md). On macOS, Vulkan runs
+through MoltenVK; Apple Silicon users normally want the built-in Metal
+backend instead. If the Vulkan library loads but reports no usable device,
+llamafile skips it and continues with the next backend rather than failing.
 
 | Vendor | Backend | Platforms | Status | Notes |
 |--------|---------|-----------|--------|-------|
 | Apple | Metal (built-in) | macOS ARM64 | Supported | Offload is enabled by default; disable with `-ngl 0` or `--gpu disable` |
 | NVIDIA | CUDA / cuBLAS | Linux, Windows, WSL | Supported | Pass `-ngl 999` to offload; Windows release binaries ship prebuilt DLLs |
 | AMD | HIP / rocBLAS | Linux, Windows | Supported | Pass `-ngl 999` to offload; multi-GPU may be broken on Radeon (see below) |
-| Intel / other | — | — | Not supported | No Vulkan or SYCL backend; runs on CPU. For these, build llama.cpp directly |
+| Any (incl. Intel) | Vulkan | Linux, Windows, macOS | Supported | Pass `-ngl 999` to offload; select with `--gpu vulkan`. Used in `--gpu auto` when no vendor backend is available |
+| Intel / other | oneAPI / SYCL | — | Not supported | No SYCL backend; use the Vulkan row above, or build llama.cpp directly |
 
 The 0.10.* series has not been tested on every GPU and platform yet, so
 treat the AMD and Windows paths in particular as best-effort.
@@ -104,9 +115,10 @@ To check:
 
 - Pass `-ngl 999` on NVIDIA and AMD to request maximum offloading (Metal
   offloads by default).
-- Force a specific backend with `--gpu nvidia` or `--gpu amd`. This turns
-  an otherwise quiet CPU fallback into an explicit startup error, which
-  makes a missing or misconfigured CUDA/ROCm toolchain easy to spot.
+- Force a specific backend with `--gpu nvidia`, `--gpu amd`, or
+  `--gpu vulkan`. This turns an otherwise quiet CPU fallback into an
+  explicit startup error, which makes a missing or misconfigured
+  CUDA/ROCm/Vulkan installation easy to spot.
 - Watch the startup logs for the messages about building and loading the
   GPU module. If you don't see them, llamafile is running on the CPU.
 

--- a/docs/support.md
+++ b/docs/support.md
@@ -41,14 +41,18 @@ There is no Intel oneAPI/SYCL backend, but Vulkan covers a lot of the
 hardware that CUDA and ROCm do not. On hardware outside the table below,
 llamafile runs on the CPU.
 
-Vulkan is loaded exactly like the CUDA and ROCm backends: llamafile looks
-for a prebuilt `ggml-vulkan.so` / `ggml-vulkan.dll`, first inside the
-bundle and then in `~/.llamafile/` — see
-[Building the GPU libraries](building_dlls.md) for where that library comes
-from on each platform. On macOS, Vulkan runs
-through MoltenVK; Apple Silicon users normally want the built-in Metal
-backend instead. If the Vulkan library loads but reports no usable device,
-llamafile skips it and continues with the next backend rather than failing.
+CUDA, ROCm, and Vulkan dynamic libraries are loaded as follows. The executable looks
+for prebuilt `ggml-(cuda|rocm|vulkan).(so|dll)` files in this order:
+
+- in the same directory (deliberately first, so a hand-built DSO overrides everything else)
+- in the llamafile bundle
+- in `~/.llamafile/v/LLAMAFILE_VERSION`
+- in `$HOME`
+
+Check out [Building the GPU libraries](building_dlls.md) for more info on how these libraries are built.
+On macOS, Vulkan runs through MoltenVK; Apple Silicon users normally want the built-in Metal
+backend instead. If any library loads but reports no usable device, llamafile skips it and continues
+with the next backend rather than failing.
 
 | Vendor | Backend | Platforms | Status | Notes |
 |--------|---------|-----------|--------|-------|


### PR DESCRIPTION
## Problem

The [GPU support section](https://docs.mozilla.ai/llamafile/reference/support#gpu-support) — which I contributed in #997 — says:

> llamafile ships GPU acceleration for Apple Metal, NVIDIA, and AMD. There is no Vulkan or Intel oneAPI/SYCL backend...

That is wrong about Vulkan, as @polarathene points out in #1029. Vulkan landed in #892 (Feb 2026) and is a first-class backend today. My PR repeated a stale assumption; this corrects it.

## What the code actually does

- `llamafile/vulkan.c` loads a prebuilt `ggml-vulkan.so` / `ggml-vulkan.dll` and registers it through `gpu_backend.c` — the *same* load → suppress-logs → device-count-gate → register path as CUDA and ROCm. `gpu_backend.h` names Vulkan explicitly as one of the prebuilt-DSO backends.
- `llamafile_gpu_parse()` in `llamafile/llamafile.c` accepts `--gpu vulkan` (alias `vk`), and `llamafile_has_vulkan()` participates in `--gpu auto` detection.
- `llamafile/release.sh` bundles both `ggml-vulkan.so` and `ggml-vulkan.dll` into the full `llamafile` release; otherwise `llamafile/vulkan.sh` / `vulkan.bat` build it (already documented in `docs/building_dlls.md`).
- macOS works via MoltenVK — `ImportVulkanImpl()` deliberately does *not* skip Apple Silicon, unlike CUDA.
- Per #988 the device-count gate means a Vulkan library that loads with 0 usable devices is skipped so fallback still happens, rather than blocking CPU fallback.

## Changes (docs only, single file)

- Intro sentence: Vulkan is shipped; only oneAPI/SYCL is missing.
- Support table: added a Vulkan row (Linux/Windows/macOS, `--gpu vulkan`), and split the old "Intel / other" row so its "Not supported" applies to oneAPI/SYCL rather than to Vulkan — it now points readers at the Vulkan row.
- Added a short paragraph on how the Vulkan library is located/built, the MoltenVK caveat on macOS, and the no-usable-device fallback behaviour.
- "Verifying GPU acceleration": listed `--gpu vulkan` next to `--gpu nvidia` / `--gpu amd`.

I deliberately kept this to facts I could verify in the tree. The open questions from the #1023 thread (prebuilt arch/libc coverage, exact fallback ordering, `.zip` artifact contents) are not asserted here.

Fixes #1029

🤖 Generated with [Claude Code](https://claude.com/claude-code)
