### PR TITLE
build(install): install transcribefile so it ships as a release artifact (#1035)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ install:	o/$(MODE)/llamafile/llamafile \
 	$(INSTALL) o/$(MODE)/llamafile/llamafile $(PREFIX)/bin/llamafile
 	$(INSTALL) o/$(MODE)/whisperfile/whisperfile $(PREFIX)/bin/whisperfile
 	$(INSTALL) o/$(MODE)/diffusionfile/diffusionfile $(PREFIX)/bin/diffusionfile
+	$(INSTALL) o/$(MODE)/transcribefile/transcribefile $(PREFIX)/bin/transcribefile
 	$(INSTALL) o/$(MODE)/third_party/zipalign/zipalign $(PREFIX)/bin/zipalign
 	mkdir -p $(PREFIX)/share/man/man1
 	$(INSTALL) -m 0644 whisperfile/whisperfile.1 $(PREFIX)/share/man/man1/whisperfile.1

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -48,7 +48,9 @@ The zip is structured as follows.
 llamafile-<version>
 |-- README.md
 |-- bin
+|   |-- diffusionfile
 |   |-- llamafile
+|   |-- transcribefile
 |   |-- whisperfile
 |   `-- zipalign
 `-- share
@@ -73,8 +75,10 @@ After you have built the zip it is quite easy to create the release binaries.
 The following binaries are part of the release:
 
 - `llamafile`
-- `whisperfile`
 - `zipalign`
+- `whisperfile`
+- `diffusionfile`
+- `transcribefile`
 
 You can use the script to create the appropriately named binaries:
 


### PR DESCRIPTION
Fixes #1035.

### What's wrong

The [0.10.4 release](https://github.com/mozilla-ai/llamafile/releases/tag/0.10.4) announces `transcribefile`, but its assets are:

```
diffusionfile-0.10.4
llamafile-0.10.4
llamafile-0.10.4-thin
llamafile-0.10.4.zip
whisperfile-0.10.4
zipalign-0.10.4
```

No `transcribefile-0.10.4`.

### Root cause

`llamafile/release.sh` already has it in the list:

```sh
BINARIES="llamafile zipalign whisperfile diffusionfile transcribefile"
```

but it copies out of `${ZIP_DIR}/bin`, and `${ZIP_DIR}` is populated by `make install`. The `install:` target installs only four binaries:

```make
	$(INSTALL) o/$(MODE)/llamafile/llamafile $(PREFIX)/bin/llamafile
	$(INSTALL) o/$(MODE)/whisperfile/whisperfile $(PREFIX)/bin/whisperfile
	$(INSTALL) o/$(MODE)/diffusionfile/diffusionfile $(PREFIX)/bin/diffusionfile
	$(INSTALL) o/$(MODE)/third_party/zipalign/zipalign $(PREFIX)/bin/zipalign
```

So `transcribefile` never lands in `bin/`, release.sh falls into its non-fatal branch —

```sh
    echo "Warning: ${ZIP_DIR}/bin/${binary} not found"
```

— and the release is cut without the binary and without failing. That also explains why the release zip's `bin/` is missing it.

### Change

Install `transcribefile` alongside `diffusionfile`. It's the same pattern and the same output path `transcribefile/BUILD.mk` already produces (`o/$(MODE)/transcribefile/transcribefile`), which the `o/$(MODE)/` aggregate target already depends on — so nothing new has to be built, it just has to be copied.

No man page entry: `transcribefile/` doesn't ship a `.1` yet, unlike `whisperfile`/`zipalign`.

`RELEASE.md` is brought in line with what `release.sh` actually produces — its release-binaries list and zip layout still described the older `llamafile` / `whisperfile` / `zipalign` set, which is part of why the gap went unnoticed.

### Verification

- `transcribefile/BUILD.mk` defines `o/$(MODE)/transcribefile/transcribefile` and the `.PHONY: o/$(MODE)/transcribefile` alias, and `Makefile`'s `o/$(MODE)/` target already lists `o/$(MODE)/transcribefile`, so the artifact exists after a plain `make -j8`.
- The new line is a copy of the `diffusionfile` line with the name substituted; `diffusionfile-0.10.4` did ship, which is the working control case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
