### PR TITLE
llamafile_open_zip: validate the zip entry window against the actual file size

### DIFF
--- a/llamafile/llamafile.c
+++ b/llamafile/llamafile.c
@@ -88,6 +88,11 @@ static struct llamafile *llamafile_open_zip(const char *prog, const char *fname,
         goto Failure;
     file->size = rc;
 
+    // the true extent of the file on disk. file->size is overwritten below with
+    // the size the zip central directory *claims*, so keep the real one to
+    // validate that claim against.
+    const uint64_t zipsize = (uint64_t)rc;
+
     // read the last 64kb of file
     // the zip file format magic can be anywhere in there
     int amt;
@@ -118,7 +123,8 @@ static struct llamafile *llamafile_open_zip(const char *prog, const char *fname,
                 (long)kZipCdir64HdrMinSize &&
             ZIP_READ32(bufdata) == kZipCdir64HdrMagic &&
             ZIP_CDIR64_RECORDS(bufdata) == ZIP_CDIR64_RECORDSONDISK(bufdata) &&
-            ZIP_CDIR64_RECORDS(bufdata) && ZIP_CDIR64_SIZE(bufdata) <= INT_MAX) {
+            ZIP_CDIR64_RECORDS(bufdata) && ZIP_CDIR64_SIZE(bufdata) > 0 &&
+            ZIP_CDIR64_SIZE(bufdata) <= INT_MAX) {
             cnt = ZIP_CDIR64_RECORDS(bufdata);
             off = ZIP_CDIR64_OFFSET(bufdata);
             amt = ZIP_CDIR64_SIZE(bufdata);
@@ -126,7 +132,8 @@ static struct llamafile *llamafile_open_zip(const char *prog, const char *fname,
         }
         if (magic == kZipCdirHdrMagic && i + kZipCdirHdrMinSize <= amt &&
             ZIP_CDIR_RECORDS(bufdata + i) == ZIP_CDIR_RECORDSONDISK(bufdata + i) &&
-            ZIP_CDIR_RECORDS(bufdata + i) && ZIP_CDIR_SIZE(bufdata + i) <= INT_MAX &&
+            ZIP_CDIR_RECORDS(bufdata + i) && ZIP_CDIR_SIZE(bufdata + i) > 0 &&
+            ZIP_CDIR_SIZE(bufdata + i) <= INT_MAX &&
             ZIP_CDIR_OFFSET(bufdata + i) != 0xffffffffu) {
             cnt = ZIP_CDIR_RECORDS(bufdata + i);
             off = ZIP_CDIR_OFFSET(bufdata + i);
@@ -174,8 +181,25 @@ static struct llamafile *llamafile_open_zip(const char *prog, const char *fname,
                    : (entry_name_len > 5 &&
                       !memcasecmp(entry_name_bytes + entry_name_len - 5, ".gguf", 5)))) {
             zip_name = gc(strndup(entry_name_bytes, entry_name_len));
-            off = get_zip_cfile_offset(cdirdata + entry_offset);
-            file->size = get_zip_cfile_compressed_size(cdirdata + entry_offset);
+            // both accessors return int64_t and use -1 to signal failure, e.g. a
+            // zip64 sentinel size with no zip64 extra field to satisfy it.
+            // Assigning that straight into uint64_t/size_t yields UINT64_MAX and
+            // makes the mapsize arithmetic below wrap.
+            int64_t entry_off = get_zip_cfile_offset(cdirdata + entry_offset);
+            int64_t entry_size = get_zip_cfile_compressed_size(cdirdata + entry_offset);
+            if (entry_off < 0 || entry_size < 0) {
+                fprintf(stderr, "%s: warning: zip entry has an unreadable offset or size\n", prog);
+                goto Invalid;
+            }
+            // the declared window must lie inside the file. written as a
+            // subtraction so it cannot overflow.
+            if ((uint64_t)entry_size > zipsize ||
+                (uint64_t)entry_off > zipsize - (uint64_t)entry_size) {
+                fprintf(stderr, "%s: warning: zip entry extends past the end of the file\n", prog);
+                goto Invalid;
+            }
+            off = (uint64_t)entry_off;
+            file->size = (size_t)entry_size;
             cdir_offset = entry_offset;
             ++found;
         }

--- a/llamafile/llamafile.c
+++ b/llamafile/llamafile.c
@@ -132,7 +132,7 @@ static struct llamafile *llamafile_open_zip(const char *prog, const char *fname,
         }
         if (magic == kZipCdirHdrMagic && i + kZipCdirHdrMinSize <= amt &&
             ZIP_CDIR_RECORDS(bufdata + i) == ZIP_CDIR_RECORDSONDISK(bufdata + i) &&
-            ZIP_CDIR_RECORDS(bufdata + i) && ZIP_CDIR_SIZE(bufdata + i) > 0 &&
+            ZIP_CDIR_RECORDS(bufdata + i) && ZIP_CDIR_SIZE(bufdata + i) >= kZipCfileHdrMinSize &&
             ZIP_CDIR_SIZE(bufdata + i) <= INT_MAX &&
             ZIP_CDIR_OFFSET(bufdata + i) != 0xffffffffu) {
             cnt = ZIP_CDIR_RECORDS(bufdata + i);
@@ -237,6 +237,15 @@ static struct llamafile *llamafile_open_zip(const char *prog, const char *fname,
         goto Invalid;
     }
     off += ZIP_LFILE_HDRSIZE(lfile);
+
+    // the local header's name and extra fields are attacker controlled (two
+    // uint16s, up to 131100 bytes total), so the window has to be revalidated
+    // after skipping them. written as a subtraction so it cannot overflow.
+    if (off > zipsize || (uint64_t)file->size > zipsize - off) {
+        fprintf(stderr, "%s: warning: zip entry data extends past the end of the file\n",
+                file->fname);
+        goto Invalid;
+    }
 
     // perform sanity check
     // mapping weights for apple metal gpu requires 16kb alignment

--- a/llamafile/llamafile.c
+++ b/llamafile/llamafile.c
@@ -123,7 +123,8 @@ static struct llamafile *llamafile_open_zip(const char *prog, const char *fname,
                 (long)kZipCdir64HdrMinSize &&
             ZIP_READ32(bufdata) == kZipCdir64HdrMagic &&
             ZIP_CDIR64_RECORDS(bufdata) == ZIP_CDIR64_RECORDSONDISK(bufdata) &&
-            ZIP_CDIR64_RECORDS(bufdata) && ZIP_CDIR64_SIZE(bufdata) > 0 &&
+            ZIP_CDIR64_RECORDS(bufdata) &&
+            ZIP_CDIR64_SIZE(bufdata) >= kZipCfileHdrMinSize &&
             ZIP_CDIR64_SIZE(bufdata) <= INT_MAX) {
             cnt = ZIP_CDIR64_RECORDS(bufdata);
             off = ZIP_CDIR64_OFFSET(bufdata);


### PR DESCRIPTION
Fixes the crash reported in #1038.

llamafile_open_zip() trusted the offset and compressed size from the zip central directory without checking them against the real file, and assigned the int64_t results of get_zip_cfile_offset() and get_zip_cfile_compressed_size() into uint64_t and size_t. Those functions return -1 on failure, so a crafted archive could set file->size to SIZE_MAX, wrap the mapsize arithmetic, and end up with a one page mapping that llamafile_size() then reported as SIZE_MAX bytes.

Three changes, all in llamafile/llamafile.c:

1. Keep the real file length from the lseek that already happens at open time. file->size holds it briefly before being overwritten at :178 by the value the archive claims, so this just preserves it as a local to validate against.

2. Take both accessor results as int64_t and reject negatives before they reach unsigned types, then require the declared window to fit inside the file. The bound is written as "entry_off > zipsize - entry_size" so it cannot overflow.

3. Require a nonzero central directory size in both the zip64 and zip32 branches. Zero passed the existing "<= INT_MAX" test and led to malloc(0) followed by a 4 byte read.

Tested against a build of 9a716e7 on Fedora 43 x86_64 and on arm64 macOS. Before the change the crafted 162 byte archive gives SIGSEGV on Linux and SIGBUS on macOS, 10 runs out of 10. After it, both are rejected with "zip entry has an unreadable offset or size", 0 out of 10. A separate archive using a plain oversized size field rather than the zip64 sentinel is rejected with "zip entry extends past the end of the file". Control archives behave exactly as before.

Regression checked against a real model. I packed a Qwen2.5-0.5B-Instruct Q4_K_M gguf into a llamafile with zipalign -j0 and ran it, so the load goes through llamafile_open_zip with legitimate values. Before and after the change it loads and generates byte-identical output. The loose-file path (-m on a plain .gguf) is unchanged too.

- [x] **AI Usage:**
    - [x] AI was used in an assistive capacity.
