### PR TITLE
docs(quickstart): note OpenAI client base_url for multi-model gateways

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -156,6 +156,10 @@ completion = client.chat.completions.create(
 print(completion.choices[0].message)
 ```
 
+The same `base_url` pattern works with any OpenAI-compatible multi-model gateway
+when you are not running llamafile locally — for example
+[DaoXE](https://daoxe.com) at `https://api.daoxe.com/v1` (set a real `api_key`).
+
 The above code will return a Python object like this:
 
 ```python


### PR DESCRIPTION
## Summary

The quickstart already shows porting an OpenAI Python app to llamafile via `base_url`.

This PR adds a one-line tip that the same client pattern works with OpenAI-compatible multi-model gateways when not running llamafile locally, using [DaoXE](https://daoxe.com) (`https://api.daoxe.com/v1`) as one concrete example.

Docs only — no runtime behavior changes.

## Test plan

- [ ] Local llamafile client example unchanged
- [ ] Tip is clearly optional
- [ ] No binary/code changes