### PR TITLE
docs: point star-history badges at star-history.dera.page

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,4 +91,4 @@ should that be desired.
 The llamafile logo on this page was generated with the assistance of DALL·E 3.
 
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Mozilla-Ocho/llamafile&type=Date)](https://star-history.com/#Mozilla-Ocho/llamafile&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Mozilla-Ocho/llamafile&type=Date)](https://star-history.dera.page/#Mozilla-Ocho/llamafile&Date)

--- a/docs/index.md
+++ b/docs/index.md
@@ -92,4 +92,4 @@ should that be desired.
 The llamafile logo on this page was generated with the assistance of DALL·E 3.
 
 
-[![Star History Chart](https://api.star-history.com/svg?repos=mozilla-ai/llamafile&type=Date)](https://star-history.com/#mozilla-ai/llamafile&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=mozilla-ai/llamafile&type=Date)](https://star-history.dera.page/#mozilla-ai/llamafile&Date)


### PR DESCRIPTION
The current star-history chart is broken due to GitHub stargazer API restrictions. Redirect all star-history links to the new domain star-history.dera.page, which uses an alternative data source and no longer needs an api subdomain.