### PR TITLE
fix: make /stats print perf metrics in TUI chat mode

### DIFF
--- a/llamafile/chatbot_direct.cpp
+++ b/llamafile/chatbot_direct.cpp
@@ -21,6 +21,7 @@
 
 #include "chat.h"
 #include "common.h"
+#include "log.h"
 #include "llama.h"
 #include "llamafile.h"
 #include "sampling.h"
@@ -95,9 +96,15 @@ public:
     }
 
     void print_stats() override {
-        FLAG_log_disable = false;
+        // common_perf_print() emits its metrics through LOG_INF(), which is
+        // gated by the common_log verbosity threshold. Chat mode sets that
+        // threshold to ERROR (chatbot_main.cpp) so LOG_INF is silently dropped
+        // and /stats prints nothing. Raise the threshold just for this call so
+        // the perf metrics reach stderr, then restore the previous value.
+        const int verbosity = common_log_get_verbosity_thold();
+        common_log_set_verbosity_thold(LOG_LEVEL_INFO);
         common_perf_print(g_ctx, g_sampler);
-        FLAG_log_disable = true;
+        common_log_set_verbosity_thold(verbosity);
     }
 
     void on_clear() override {


### PR DESCRIPTION
## Description

`/stats` prints nothing in the TUI chat on 0.10.x. The command goes through
`DirectBackend::print_stats()`, which calls `common_perf_print()`. That helper
emits its metrics through `LOG_INF()`, and chat mode sets the `common_log`
verbosity threshold to `LOG_LEVEL_ERROR` to silence model-loading logs
(`chatbot_main.cpp`). Because `LOG_INF` is gated by that threshold, the perf
output is dropped and `/stats` shows nothing.

The fix raises the verbosity threshold back to INFO just for the call, then
restores the previous value. Perf output reaches stderr without changing the
quiet-mode behavior during normal generation.

## PR Type

- 🐛 Bug Fix

## Relevant issues

Fixes #1047

## Checklist

- [x] I understand the code I am submitting.
- [x] I have run this code locally and verified the change.
- [x] New and existing tests pass locally, or I have explained why tests were not run.
- [ ] Documentation was updated where necessary.
- [x] If I changed code in `llama.cpp/`, `whisper.cpp/`, or `stable-diffusion.cpp/`, I also updated the matching `*.patches/` files.
- [x] I have read and followed the contribution guidelines.
- [ ] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used in an assistive capacity.
    - [ ] This PR includes substantial AI-generated content.

## AI Usage Information

Verified end to end: built the change under cosmocc, then ran the TUI chat
(`llamafile -m TinyLLama-v0.1-5M-F16.gguf --chat`) and issued `/stats`. The
perf metrics printed (sampling time, prompt eval time, eval time, total time).
A control run without `/stats` printed none, so the output comes from the
command, not from an automatic print at exit. I did not run the full test
suite; this is a one-line verbosity adjustment in an existing override.

When answering reviewer questions, please respond yourself rather than pasting reviewer comments into an AI system and posting the reply back unchanged.

- [ ] I am an AI Agent filling out this form (check box if true)
