### PR TITLE
fix(build): compile the ggml objects with -DNDEBUG

### DIFF
--- a/llama.cpp.patches/llamafile-files/BUILD.mk
+++ b/llama.cpp.patches/llamafile-files/BUILD.mk
@@ -553,8 +553,10 @@ $(COMMON_OBJS): private CCFLAGS += -DLLAMA_USE_HTTPLIB
 # agree on it.
 $(LLAMA_CPP_OBJS) $(TOOL_SERVER_OBJS): private CPPFLAGS += -DLLAMA_SUBPROCESS
 
-# Optimization flags for specific components
-$(LLAMA_OBJS) $(COMMON_OBJS): private CCFLAGS += -DNDEBUG
+# Compile out assert() across llama.cpp, as upstream's Release build does.
+# The ggml objects were missing this, so asserts stayed live in the CPU hot
+# path. GGML_ASSERT is unaffected: it calls ggml_abort(), not assert().
+$(LLAMA_CPP_OBJS): private CCFLAGS += -DNDEBUG
 
 # Memory management and backend - use default -O2 (backend is in hot path)
 o/$(MODE)/llama.cpp/ggml/src/ggml-alloc.c.o \


### PR DESCRIPTION
## Description

`llama.cpp/BUILD.mk` used the `-DNDEBUG` flag with `llama` and `common` targets, but not with the ggml
objects, so plain `assert()` stayed live in the CPU hot path (upstream's Release build, instead, compiles them out).

```make
-$(LLAMA_OBJS) $(COMMON_OBJS): private CCFLAGS += -DNDEBUG
+$(LLAMA_CPP_OBJS): private CCFLAGS += -DNDEBUG
```

`LLAMA_CPP_OBJS` is the existing umbrella variable (`GGML + LLAMA + COMMON + GGUF`).

**What was running:** 25 `#ifndef NDEBUG` blocks in `ops.cpp` that re-read each FFN
activation output row checking `isnan`/`isinf` (swiglu, silu, gelu, geglu…), plus
per-row asserts in the quant dot-products.

**Measured** (token generation, interleaved A/B, medians):

| path | gain | why |
|---|---|---|
| CPU x86 (9B / 27B) | +1.25% / +1.19% | ggml built here — was missing the flag |
| CPU arm64 (9B) | +1.00% | same |
| CUDA | +0.34% | kernels already had it; only shared host code gained |
| Metal | 0.00% | `metal.c` rebuilds ggml at runtime, already with `-DNDEBUG` |

Binary shrinks 77–94 KB. `make check` passes.

**Trade-off:** two `GGML_LOG_DEBUG` diagnostics go quiet (`ggml-backend.cpp:496`
"slow copy", `:899` "no backend supports op"), both useful when debugging offload.
Same as upstream Release.

**Not covered:** `whisper.cpp` and `transcribe.cpp` build their own ggml copies and
still lack the flag — separate PR. `stable-diffusion.cpp` reuses `$(GGML_OBJS)` and
benefits for free.

## PR Type
<!-- Delete the types that don't apply -->

- 💅 Refactor

## Relevant issues

#980 - see [this](https://github.com/mozilla-ai/llamafile/issues/980#issuecomment-5077578913) in particular, TY @dexhunter !

## Checklist
<!-- If this checklist is deleted from the PR submission it may be closed -->
- [x] I understand the code I am submitting.
- [x] I have run this code locally and verified the change.
- [x] New and existing tests pass locally, or I have explained why tests were not run.
- [x] I have read and followed the [contribution guidelines](https://github.com/mozilla-ai/llamafile/blob/main/CONTRIBUTING.md).
- [x] **AI Usage:**
    - [ ] No AI was used.
    - [x] AI was used in an assistive capacity (to run tests for the 1-line manual change)
    - [ ] This PR includes substantial AI-generated content.
